### PR TITLE
Improve `eftl-jakartaeetck-build-900` job so it keeps a history

### DIFF
--- a/jobs/common/backup.sh
+++ b/jobs/common/backup.sh
@@ -20,7 +20,7 @@ function backup {
 
     NAME="${FILE/.zip/}"
     SHA=$(sha256sum "$FILE" | sed 's, .*,,')
-    DATE="$(date +"%Y-%m-%d-%s")"
+    DATE="$(date +"%Y-%m-%d")"
 
     SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 

--- a/jobs/common/backup.sh
+++ b/jobs/common/backup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+
+##
+## Functions that will backup binaries to a specific
+## location in the target host and retain at most
+## five copies at a time.
+##
+## This script is meant to be "imported" as follows:
+##
+## source "$(dirname $0)/../common/backup.sh"
+##
+
+function backup {
+    FILE="${1?Specify a binary}"
+    HOST="${2?Specify a host}"
+    DEST="${3?Specify a destination directory in $HOST}"
+
+    #################################################
+
+    NAME="${FILE/.zip/}"
+    SHA=$(sha256sum "$FILE" | sed 's, .*,,')
+    DATE="$(date +"%Y-%m-%d-%s")"
+
+    SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+    # Delete all but the last 4 most recent binaries
+    ssh $SSH_OPTS "$HOST" ls -t "$DEST" | tail -n +5 | while read n; do
+	ssh $SSH_OPTS "$HOST" rm "$DEST/$n"
+    done
+
+    # Upload the latest binary with correct date and sha
+    scp $SSH_OPTS "$FILE" "$HOST:$DEST/$NAME-$DATE-$SHA.zip"
+}

--- a/jobs/eftl-jakartaeetck-build-900/publish.sh
+++ b/jobs/eftl-jakartaeetck-build-900/publish.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -x
 
+##[ Imports ]####################
+
+source "$(dirname $0)/../common/backup.sh"
+
+##[ Main ]#######################
+
 #GF_VER=`cat glassfish.version | tr '\n' '|'`
 TCK_VER=`cat jakartaeetck.version | tr '\n' '|'`
 echo "Version Info:Eclipse GF URL : https://ci.eclipse.org/jakartaee-tck/job/build-glassfish/lastSuccessfulBuild/artifact/appserver/distributions/glassfish/target/glassfish.zip ; JakartaEETCK-$TCK_VER"
@@ -36,8 +42,14 @@ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null jakarta-jakartae
 scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $WORKSPACE/jakartaeetck.version genie.jakartaee-tck@build.eclipse.org:/home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900
 scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $WORKSPACE/jakarta-jakartaeetckinfo.txt genie.jakartaee-tck@build.eclipse.org:/home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900
 
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null genie.jakartaee-tck@build.eclipse.org ls -lt /home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900
+
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null genie.jakartaee-tck@build.eclipse.org mkdir /home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900/history
+
+backup jakarta-jakartaeetck-9.0.0.zip \
+       genie.jakartaee-tck@build.eclipse.org \
+       /home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900/history
+
 rm -rf jakarta-jakartaeetck-9.0.0.zip
 rm -rf jakarta-jakartaee-smoke-9.0.0.zip
-
-ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null genie.jakartaee-tck@build.eclipse.org ls -lt /home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900
 

--- a/jobs/eftl-jakartaeetck-build-900/publish.sh
+++ b/jobs/eftl-jakartaeetck-build-900/publish.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -x
+
+#GF_VER=`cat glassfish.version | tr '\n' '|'`
+TCK_VER=`cat jakartaeetck.version | tr '\n' '|'`
+echo "Version Info:Eclipse GF URL : https://ci.eclipse.org/jakartaee-tck/job/build-glassfish/lastSuccessfulBuild/artifact/appserver/distributions/glassfish/target/glassfish.zip ; JakartaEETCK-$TCK_VER"
+
+for f in *junitreports.tar.gz
+do
+  tar zxf "$f" -C $WORKSPACE  --strip-components=5
+  touch */*.xml
+done
+
+ls -ltr
+cd jakartaeetck-bundles/
+ls -ltr
+
+rm -rf $WORKSPACE/jakarta-jakartaeetckinfo.txt
+touch $WORKSPACE/jakarta-jakartaeetckinfo.txt
+export BUNDLE_URL="http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900"
+
+for tck_bundle in *tck*.zip
+do
+  export NAME=$tck_bundle
+  echo '***********************************************************************************' >> $WORKSPACE/jakarta-jakartaeetckinfo.txt
+  echo '***                        TCK bundle information                               ***' >> $WORKSPACE/jakarta-jakartaeetckinfo.txt
+  echo "*** Name:       ${NAME}                                     ***" >> $WORKSPACE/jakarta-jakartaeetckinfo.txt
+  echo "*** Bundle Copied to URL:    ${BUNDLE_URL}/${NAME} ***"  >> $WORKSPACE/jakarta-jakartaeetckinfo.txt
+  echo '*** Date and size: '`stat -c "date: %y, size(b): %s" ${NAME}`'        ***'>> $WORKSPACE/jakarta-jakartaeetckinfo.txt
+  echo "*** SHA256SUM: "`sha256sum ${NAME} | awk '{print $1}'`' ***' >> $WORKSPACE/jakarta-jakartaeetckinfo.txt
+  echo '***                                                                             ***' >> $WORKSPACE/jakarta-jakartaeetckinfo.txt
+  echo '***********************************************************************************' >> $WORKSPACE/jakarta-jakartaeetckinfo.txt
+done
+
+
+scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null jakarta-jakartaeetck-9.0.0.zip genie.jakartaee-tck@build.eclipse.org:/home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900
+scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $WORKSPACE/jakartaeetck.version genie.jakartaee-tck@build.eclipse.org:/home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900
+scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $WORKSPACE/jakarta-jakartaeetckinfo.txt genie.jakartaee-tck@build.eclipse.org:/home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900
+
+rm -rf jakarta-jakartaeetck-9.0.0.zip
+rm -rf jakarta-jakartaee-smoke-9.0.0.zip
+
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null genie.jakartaee-tck@build.eclipse.org ls -lt /home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900
+


### PR DESCRIPTION
In this PR there is a new `jobs` directory where we can put the scripts we've been using for the various jobs so they are revision controlled.  This also could greatly reduce duplication.  If we like the pattern, I'll move all the scripts over.

There is also a reusable script that can create a history of past builds so we have a bit of retention (5 builds).  If a particular build of the TCK results in a passing run, the project can indicate by SHA which TCK they want promoted.

 - https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900/history/

