### PR TITLE
temporarily remove the max number of backups

### DIFF
--- a/jobs/common/backup.sh
+++ b/jobs/common/backup.sh
@@ -32,3 +32,20 @@ function backup {
     # Upload the latest binary with correct date and sha
     scp $SSH_OPTS "$FILE" "$HOST:$DEST/$NAME-$DATE-$SHA.zip"
 }
+
+function backup_no_delete {
+    FILE="${1?Specify a binary}"
+    HOST="${2?Specify a host}"
+    DEST="${3?Specify a destination directory in $HOST}"
+
+    #################################################
+
+    NAME="${FILE/.zip/}"
+    SHA=$(sha256sum "$FILE" | sed 's, .*,,')
+    DATE="$(date +"%Y-%m-%d")"
+
+    SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+    # Upload the latest binary with correct date and sha
+    scp $SSH_OPTS "$FILE" "$HOST:$DEST/$NAME-$DATE-$SHA.zip"
+}

--- a/jobs/eftl-jakartaeetck-build-900/publish.sh
+++ b/jobs/eftl-jakartaeetck-build-900/publish.sh
@@ -46,7 +46,8 @@ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null genie.jakartaee-
 
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null genie.jakartaee-tck@build.eclipse.org mkdir /home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900/history
 
-backup jakarta-jakartaeetck-9.0.0.zip \
+# backup limits the number of zips kept to 5, instead we will temporily switch to backup_no_delete which doesn't limit the number of zips.
+backup_no_delete jakarta-jakartaeetck-9.0.0.zip \
        genie.jakartaee-tck@build.eclipse.org \
        /home/data/httpd/download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-900/history
 


### PR DESCRIPTION
This should allow us to keep an unlimited number of Platform TCK zips in history for a little while (until we release EE 9).