### PR TITLE
Update the rewrite rules to use openrewrite 8.7.2

### DIFF
--- a/tools/tck-rewrite/pom.xml
+++ b/tools/tck-rewrite/pom.xml
@@ -15,7 +15,7 @@
         <version.arquillian>1.7.0.Final</version.arquillian>
         <version.http-commons>3.1</version.http-commons>
         <version.javatest>5.0</version.javatest>
-        <version.openrewrite>7.40.8</version.openrewrite>
+        <version.openrewrite>8.7.2</version.openrewrite>
         <version.servlet-api>6.0.0</version.servlet-api>
         <version.tcktools>11.0.0-SNAPSHOT</version.tcktools>
     </properties>
@@ -116,6 +116,11 @@
             <version>10.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>jakartatck</groupId>
+            <artifactId>ejb</artifactId>
+            <version>10.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.8.1</version>
@@ -164,6 +169,11 @@
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
             <version>4.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.36</version>
         </dependency>
     </dependencies>
 

--- a/tools/tck-rewrite/src/main/java/tck/jakarta/platform/rewrite/ConvertJavaTestNameRecipe.java
+++ b/tools/tck-rewrite/src/main/java/tck/jakarta/platform/rewrite/ConvertJavaTestNameRecipe.java
@@ -2,6 +2,7 @@ package tck.jakarta.platform.rewrite;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import java.time.Duration;
 
@@ -29,7 +30,7 @@ public class ConvertJavaTestNameRecipe extends Recipe {
     }
 
     @Override
-    protected JavaIsoVisitor<ExecutionContext> getVisitor() {
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new ConvertJavaTestNameVisitor<>();
     }
 }

--- a/tools/tck-rewrite/src/main/java/tck/jakarta/platform/rewrite/ConvertJavaTestNameVisitor.java
+++ b/tools/tck-rewrite/src/main/java/tck/jakarta/platform/rewrite/ConvertJavaTestNameVisitor.java
@@ -23,7 +23,7 @@ public class ConvertJavaTestNameVisitor<ExecutionContext> extends JavaIsoVisitor
     private final AnnotationMatcher TEST_ANN_MATCH = new AnnotationMatcher("@org.junit.jupiter.api.Test");
 
     private final JavaTemplate testAnnotationTemplate =
-            JavaTemplate.builder(this::getCursor, "@Test")
+            JavaTemplate.builder( "@Test")/*[Rewrite8 migration] contextSensitive() could be unnecessary, please follow the migration guide*/.contextSensitive()
                     .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
                     .imports("org.junit.jupiter.api.Test")
                     .build();
@@ -47,7 +47,7 @@ public class ConvertJavaTestNameVisitor<ExecutionContext> extends JavaIsoVisitor
                         String name = ((Javadoc.UnknownBlock) jd).getName();
                         if(name.equals("testName:")) {
                             // Javadoc comment with a @testName tag
-                            method = method.withTemplate(testAnnotationTemplate,
+                            method = testAnnotationTemplate.apply(/*[Rewrite8 migration] getCursor() could be updateCursor() if the J instance is updated, or it should be updated to point to the correct cursor, please follow the migration guide*/getCursor(),
                                     method.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
                             maybeAddImport("org.junit.jupiter.api.Test");
                             log.fine("Added @Test annotation to: "+method);
@@ -63,7 +63,7 @@ public class ConvertJavaTestNameVisitor<ExecutionContext> extends JavaIsoVisitor
                     // Java comment with a @testName tag
                     String name = text.substring(testNameIndex+9).strip();
                     String[] parts = name.split("[\s\n\t]+");
-                    method = method.withTemplate(testAnnotationTemplate,
+                    method = testAnnotationTemplate.apply(/*[Rewrite8 migration] getCursor() could be updateCursor() if the J instance is updated, or it should be updated to point to the correct cursor, please follow the migration guide*/getCursor(),
                             method.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
                     maybeAddImport("org.junit.jupiter.api.Test", null, false);
                     log.fine("Added @Test annotation to: "+method);

--- a/tools/tck-rewrite/src/main/java/tck/jakarta/platform/rewrite/JavaTestToArquillianShrinkwrap.java
+++ b/tools/tck-rewrite/src/main/java/tck/jakarta/platform/rewrite/JavaTestToArquillianShrinkwrap.java
@@ -2,6 +2,7 @@ package tck.jakarta.platform.rewrite;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 
 import java.time.Duration;
@@ -12,13 +13,6 @@ import java.time.Duration;
  * conversions.
  */
 public class JavaTestToArquillianShrinkwrap extends Recipe {
-
-    /**
-     * Chain this Recipe to the ConvertJavaTestNameRecipe
-     */
-    public JavaTestToArquillianShrinkwrap() {
-        doNext(new ConvertJavaTestNameRecipe());
-    }
 
     @Override
     public String getDisplayName() {
@@ -36,7 +30,7 @@ public class JavaTestToArquillianShrinkwrap extends Recipe {
     }
 
     @Override
-    protected JavaIsoVisitor<ExecutionContext> getVisitor() {
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new AddArquillianDeployMethod<>();
     }
 }

--- a/tools/tck-rewrite/src/test/java/tck/conversion/rewrite/AddArqDeploymentTest.java
+++ b/tools/tck-rewrite/src/test/java/tck/conversion/rewrite/AddArqDeploymentTest.java
@@ -1,54 +1,38 @@
 package tck.conversion.rewrite;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
+import org.openrewrite.*;
+import org.openrewrite.config.CompositeRecipe;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import org.openrewrite.xml.ChangeTagContentVisitor;
 import tck.jakarta.platform.rewrite.AddArquillianDeployMethod;
 import tck.jakarta.platform.rewrite.ConvertJavaTestNameRecipe;
+import tck.jakarta.platform.rewrite.ConvertJavaTestNameVisitor;
+import tck.jakarta.platform.rewrite.JavaTestToArquillianShrinkwrap;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.openrewrite.java.Assertions.java;
-
-/**
- * The test recipe which combines the AddArquillianDeployMethod and
- * ConvertJavaTestNameRecipe recipes.
- */
-class LocalRecipe extends Recipe {
-    LocalRecipe() {
-        doNext(new ConvertJavaTestNameRecipe());
-    }
-    @Override
-    public String getDisplayName() {
-        return "Add missing @Deployment";
-    }
-
-    @Override
-    public String getDescription() {
-        return getDisplayName() + ".";
-    }
-
-    @Override
-    protected JavaIsoVisitor<ExecutionContext> getVisitor() {
-        return new AddArquillianDeployMethod<>();
-    }
-
-}
 
 public class AddArqDeploymentTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         Path testClasses = Paths.get("/Users/starksm/Dev/Jakarta/tck-rewrite-tools/target", "test-classes");
 
-        spec
-                .recipe(new LocalRecipe())
+        Recipe[] toRun = {new JavaTestToArquillianShrinkwrap(), new ConvertJavaTestNameRecipe()};
+        CompositeRecipe testRecipes = new CompositeRecipe(Arrays.asList(toRun));
+
+        spec.recipe(testRecipes)
                 .parser(JavaParser.fromJavaVersion()
                         .classpath(JavaParser.runtimeClasspath())
                 );
@@ -59,11 +43,11 @@ public class AddArqDeploymentTest implements RewriteTest {
         rewriteRun(
                 java(
                         """
-                                    package com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes;
+                                    package com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics;
                                     
-                                    import com.sun.ts.tests.servlet.common.client.AbstractUrlClient;
+                                    import com.sun.ts.lib.harness.EETest;
                                     
-                                    public class SomeTestClass extends AbstractUrlClient {
+                                    public class Client extends EETest {
                                   
                                         /**
                                         @testName: someTestMethod
@@ -73,35 +57,51 @@ public class AddArqDeploymentTest implements RewriteTest {
                                     }
                                 """,
                         """
-                                    package com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes;
+                                    package com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics;
                                     
-                                    import com.sun.ts.tests.servlet.common.client.AbstractUrlClient;
+                                    import com.sun.ts.lib.harness.EETest;
                                     import org.jboss.arquillian.container.test.api.Deployment;
+                                    import org.jboss.shrinkwrap.api.Archive;
                                     import org.jboss.shrinkwrap.api.ShrinkWrap;
+                                    import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
                                     import org.jboss.shrinkwrap.api.spec.JavaArchive;
-                                    import org.jboss.shrinkwrap.api.spec.WebArchive;
                                     import org.junit.jupiter.api.Test;
                                     
-                                    public class SomeTestClass extends AbstractUrlClient {
+                                    public class Client extends EETest {
                                     
                                         @Deployment(testable = false)
-                                        public static WebArchive getTestArchive() throws Exception {
-                                        
-                                            WebArchive servlet_sci_setsessiontrackingmode_web_war = ShrinkWrap.create(WebArchive.class, "servlet_sci_setsessiontrackingmode_web_war");
-                                            servlet_sci_setsessiontrackingmode_web_war.addAsWebInfResource("web.xml");
-                                                                       
-                                            JavaArchive initilizer_jar = ShrinkWrap.create(JavaArchive.class, "initilizer.jar");
-                                            initilizer_jar.addClass(com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes.TCKServletContainerInitializer.class);
-                                            initilizer_jar.addAsManifestResource("META-INF/MANIFEST.MF");
-                                            initilizer_jar.addAsManifestResource("META-INF/services/jakarta.servlet.ServletContainerInitializer");
-                                            servlet_sci_setsessiontrackingmode_web_war.addAsLibrary(initilizer_jar);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes.TCKServletContainerInitializer.class);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes.TestListener.class);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes.TestServlet.class);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.common.servlets.GenericTCKServlet.class);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.common.util.Data.class);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.common.util.ServletTestUtil.class);
-                                            return servlet_sci_setsessiontrackingmode_web_war;                   
+                                        public static Archive<?> deployment() {
+                                    
+                                            final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "ejb_bb_ssl_argsemantics.ear");
+                                            // Add ear submodules
+                                    
+                                            JavaArchive ejb_bb_ssl_argsemantics_client_jar = ShrinkWrap.create(JavaArchive.class, "ejb_bb_ssl_argsemantics_client_jar");
+                                            ejb_bb_ssl_argsemantics_client_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBean.class);
+                                            ejb_bb_ssl_argsemantics_client_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBeanHome.class);
+                                            ejb_bb_ssl_argsemantics_client_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.Client.class);
+                                            ear.addAsModule(ejb_bb_ssl_argsemantics_client_jar);
+                                    
+                                            JavaArchive ejb_bb_ssl_argsemantics_ejb_jar = ShrinkWrap.create(JavaArchive.class, "ejb_bb_ssl_argsemantics_ejb_jar");
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBean.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBeanEJB.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBeanHome.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.CMP20Callee.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.CMP20CalleeEJB.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.CMP20CalleeHome.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.CMP20CalleeLocal.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.CMP20CalleeLocalHome.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.SimpleArgument.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.StatefulCallee.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.StatefulCalleeEJB.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.StatefulCalleeHome.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.StatefulCalleeLocal.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.StatefulCalleeLocalHome.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.wrappers.CMP20Wrapper.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper.class);
+                                            ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.testlogic.ejb.bb.argsemantics.TestLogic.class);
+                                            ear.addAsModule(ejb_bb_ssl_argsemantics_ejb_jar);
+                                            return ear;                 
                                         }
                                   
                                         /**

--- a/tools/tck-rewrite/src/test/java/tck/conversion/rewrite/JavaTestToArqTest.java
+++ b/tools/tck-rewrite/src/test/java/tck/conversion/rewrite/JavaTestToArqTest.java
@@ -1,9 +1,12 @@
 package tck.conversion.rewrite;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import tck.jakarta.platform.rewrite.ConvertJavaTestNameRecipe;
 import tck.jakarta.platform.rewrite.JavaTestToArquillianShrinkwrap;
 
 import java.io.IOException;
@@ -21,78 +24,15 @@ import static org.openrewrite.java.Assertions.java;
 class JavaTestToArqTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
+        Recipe[] toRun = {new JavaTestToArquillianShrinkwrap(), new ConvertJavaTestNameRecipe()};
+        CompositeRecipe testRecipes = new CompositeRecipe(Arrays.asList(toRun));
+
         spec
-                .recipe(new JavaTestToArquillianShrinkwrap())
+                .recipe(testRecipes)
                 .parser(JavaParser.fromJavaVersion()
                         .classpath(JavaParser.runtimeClasspath())
                 )
         ;
-    }
-
-    /**
-     * Test of a war deployment from the com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes
-     * pkg.
-     */
-    @Test
-    void addDeploymentMethod() {
-        rewriteRun(
-                java(
-                        """
-                                    package com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes;
-                                    
-                                    import com.sun.ts.tests.servlet.common.client.AbstractUrlClient;
-                                    
-                                    public class SomeTestClass extends AbstractUrlClient {
-                                  
-                                        /**
-                                        @testName: someTestMethod
-                                        */
-                                        public void someTestMethod() {
-                                        }
-                                    }
-                                """,
-                        """
-                                    package com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes;
-                                    
-                                    import com.sun.ts.tests.servlet.common.client.AbstractUrlClient;
-                                    import org.jboss.arquillian.container.test.api.Deployment;
-                                    import org.jboss.shrinkwrap.api.ShrinkWrap;
-                                    import org.jboss.shrinkwrap.api.spec.JavaArchive;
-                                    import org.jboss.shrinkwrap.api.spec.WebArchive;
-                                    import org.junit.jupiter.api.Test;
-                                    
-                                    public class SomeTestClass extends AbstractUrlClient {
-                                    
-                                        @Deployment(testable = false)
-                                        public static WebArchive getTestArchive() throws Exception {
-
-                                            WebArchive servlet_sci_setsessiontrackingmode_web_war = ShrinkWrap.create(WebArchive.class, "servlet_sci_setsessiontrackingmode_web_war");
-                                            servlet_sci_setsessiontrackingmode_web_war.addAsWebInfResource("web.xml");
-                                    
-                                            JavaArchive initilizer_jar = ShrinkWrap.create(JavaArchive.class, "initilizer.jar");
-                                            initilizer_jar.addClass(com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes.TCKServletContainerInitializer.class);
-                                            initilizer_jar.addAsManifestResource("META-INF/MANIFEST.MF");
-                                            initilizer_jar.addAsManifestResource("META-INF/services/jakarta.servlet.ServletContainerInitializer");
-                                            servlet_sci_setsessiontrackingmode_web_war.addAsLibrary(initilizer_jar);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes.TCKServletContainerInitializer.class);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes.TestListener.class);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.api.jakarta_servlet.scinitializer.setsessiontrackingmodes.TestServlet.class);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.common.servlets.GenericTCKServlet.class);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.common.util.Data.class);
-                                            servlet_sci_setsessiontrackingmode_web_war.addClass(com.sun.ts.tests.servlet.common.util.ServletTestUtil.class);
-                                            return servlet_sci_setsessiontrackingmode_web_war;
-                                        }
-                                  
-                                        /**
-                                        @testName: someTestMethod
-                                        */
-                                        @Test
-                                        public void someTestMethod() {
-                                        }
-                                    }
-                                """
-                )
-        );
     }
 
     @Test
@@ -103,7 +43,7 @@ class JavaTestToArqTest implements RewriteTest {
     }
 
     /**
-     * A test from the com.sun.ts.tests.servlet.api.jakarta_servlet_http.sessioncookieconfig pkg that has several
+     * A test from the com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics pkg that has several
      * methods. The before and after source are read in from the LargeCaseBefore.java/LargeCaseAfter.java files
      *
      * @throws IOException
@@ -112,7 +52,7 @@ class JavaTestToArqTest implements RewriteTest {
     @Test
     public void testLargeCase() throws IOException {
         String className = "LargeCase";
-        String pkg = "com.sun.ts.tests.servlet.api.jakarta_servlet_http.sessioncookieconfig";
+        String pkg = "com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics";
         runTestFromSource(className, pkg);
     }
 

--- a/tools/tck-rewrite/src/test/java/tck/conversion/rewrite/LargeCaseAfter.java
+++ b/tools/tck-rewrite/src/test/java/tck/conversion/rewrite/LargeCaseAfter.java
@@ -1,13 +1,20 @@
-//package com.sun.ts.tests.servlet.api.jakarta_servlet_http.sessioncookieconfig;
+//package com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics;
 package tck.conversion.rewrite;
 
-import java.io.PrintWriter;
+import java.util.Properties;
 
 import com.sun.javatest.Status;
-import com.sun.ts.tests.servlet.common.client.AbstractUrlClient;
+import com.sun.ts.lib.harness.EETest;
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
+import com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBean;
+import com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBeanHome;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -17,194 +24,415 @@ import org.junit.jupiter.api.Test;
  * and syntax checked. The class name and package are replaced by the testLargeCase method.
  */
 @Disabled
-public class LargeCaseAfter extends AbstractUrlClient {
+public class LargeCaseAfter extends EETest {
 
     @Deployment(testable = false)
-    public static WebArchive getTestArchive() throws Exception {
+    public static Archive<?> deployment() {
 
-        WebArchive servlet_jsh_sessioncookieconfig_web_war = ShrinkWrap.create(WebArchive.class, "servlet_jsh_sessioncookieconfig_web_war");
-        servlet_jsh_sessioncookieconfig_web_war.addAsWebInfResource("web.xml");
-        servlet_jsh_sessioncookieconfig_web_war.addClass(com.sun.ts.tests.servlet.api.jakarta_servlet_http.sessioncookieconfig.TestListener.class);
-        servlet_jsh_sessioncookieconfig_web_war.addClass(com.sun.ts.tests.servlet.api.jakarta_servlet_http.sessioncookieconfig.TestServlet.class);
-        servlet_jsh_sessioncookieconfig_web_war.addClass(com.sun.ts.tests.servlet.common.servlets.HttpTCKServlet.class);
-        servlet_jsh_sessioncookieconfig_web_war.addClass(com.sun.ts.tests.servlet.common.util.Data.class);
-        servlet_jsh_sessioncookieconfig_web_war.addClass(com.sun.ts.tests.servlet.common.util.ServletTestUtil.class);
-        return servlet_jsh_sessioncookieconfig_web_war;
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "ejb_bb_ssl_argsemantics.ear");
+        // Add ear submodules
+
+        JavaArchive ejb_bb_ssl_argsemantics_client_jar = ShrinkWrap.create(JavaArchive.class, "ejb_bb_ssl_argsemantics_client_jar");
+        ejb_bb_ssl_argsemantics_client_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBean.class);
+        ejb_bb_ssl_argsemantics_client_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBeanHome.class);
+        ejb_bb_ssl_argsemantics_client_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.Client.class);
+        ear.addAsModule(ejb_bb_ssl_argsemantics_client_jar);
+
+        JavaArchive ejb_bb_ssl_argsemantics_ejb_jar = ShrinkWrap.create(JavaArchive.class, "ejb_bb_ssl_argsemantics_ejb_jar");
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBean.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBeanEJB.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.CallerBeanHome.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.CMP20Callee.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.CMP20CalleeEJB.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.CMP20CalleeHome.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.CMP20CalleeLocal.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.CMP20CalleeLocalHome.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.SimpleArgument.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.StatefulCallee.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.StatefulCalleeEJB.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.StatefulCalleeHome.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.StatefulCalleeLocal.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.calleebeans.StatefulCalleeLocalHome.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.wrappers.CMP20Wrapper.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper.class);
+        ejb_bb_ssl_argsemantics_ejb_jar.addClass(com.sun.ts.tests.common.testlogic.ejb.bb.argsemantics.TestLogic.class);
+        ear.addAsModule(ejb_bb_ssl_argsemantics_ejb_jar);
+        return ear;
     }
 
-    /**
-     * Entry point for different-VM execution. It should delegate to method
-     * run(String[], PrintWriter, PrintWriter), and this method should not contain
-     * any test configuration.
-     */
+    private static final String testName = "EntityBeanTest";
+
+    private static final String beanLookup = "java:comp/env/ejb/Caller";
+
+    private CallerBean bean = null;
+
+    private CallerBeanHome beanHome = null;
+
+    private Properties props = null;
+
+    private TSNamingContext nctx = null;
+
     public static void main(String[] args) {
-        com.sun.ts.tests.servlet.api.jakarta_servlet_http.sessioncookieconfig.URLClient theTests = new com.sun.ts.tests.servlet.api.jakarta_servlet_http.sessioncookieconfig.URLClient();
-        Status s = theTests.run(args, new PrintWriter(System.out),
-                new PrintWriter(System.err));
+        com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.Client theTests = new com.sun.ts.tests.ejb.ee.bb.session.stateless.argsemantics.Client();
+        Status s = theTests.run(args, System.out, System.err);
         s.exit();
     }
 
     /**
-     * Entry point for same-VM execution. In different-VM execution, the main
-     * method delegates to this method.
+     * @class.setup_props: org.omg.CORBA.ORBClass; java.naming.factory.initial;
+     *                     generateSQL;
      */
-    public Status run(String args[], PrintWriter out, PrintWriter err) {
+    public void setup(String[] args, Properties props) throws Fault {
+        try {
+            logMsg("[Client] setup()");
+            this.props = props;
 
-        setContextRoot("/servlet_jsh_sessioncookieconfig_web");
-        setServletName("TestServlet");
+            logTrace("[Client] Getting Naming Context...");
+            nctx = new TSNamingContext();
 
-        return super.run(args, out, err);
+            logTrace("[Client] Looking up " + beanLookup);
+            beanHome = (CallerBeanHome) nctx.lookup(beanLookup, CallerBeanHome.class);
+            logTrace("[Client] Create EJB instance...");
+            bean = (CallerBean) beanHome.create();
+        } catch (Exception e) {
+            throw new Fault("Setup failed:", e);
+        }
     }
 
-    /*
-     * @class.setup_props: webServerHost; webServerPort; ts_home;
-     */
-    /* Run test */
-    /*
-     * @testName: constructortest1
+    /**
+     * @testName: testStatefulRemote
      *
-     * @assertion_ids: Servlet:JAVADOC:693; Servlet:JAVADOC:733;
-     * Servlet:JAVADOC:734; Servlet:JAVADOC:735; Servlet:JAVADOC:736;
-     * Servlet:JAVADOC:737; Servlet:JAVADOC:738; Servlet:JAVADOC:739;
-     * Servlet:JAVADOC:740; Servlet:JAVADOC:741; Servlet:JAVADOC:742;
-     * Servlet:JAVADOC:743; Servlet:JAVADOC:744; Servlet:JAVADOC:745;
-     * Servlet:JAVADOC:746;
+     * @assertion_ids: EJB:SPEC:906
      *
-     * @test_Strategy: Create a Servlet TestServlet, with a
-     * ServletContextListener; In the Servlet, turn HttpSession on; In
-     * ServletContextListener, create a SessionCookieConfig instance, Verify in
-     * Client that the SessionCookieConfig instance is created, and all
-     * SessionCookieConfig APIs work accordingly.
+     * @test_Strategy:
+     *
+     *                 This is applicable to : - a Session Stateful Callee bean
+     *                 defining a remote client view only (No local view). - a
+     *                 Stateless Caller bean, Calling this Callee Bean home or
+     *                 remote interface.
+     *
+     *                 We package in the same ejb-jar: - a Session Stateful Callee
+     *                 bean defining a remote client view only (No local view). -
+     *                 a Stateless Caller bean
+     *
+     *                 Remote Home arg semantics verification:
+     *
+     *                 - We set a non-remote object 'arg' (of type SimpleArgument)
+     *                 to an initial value. This SimpleArgument class is just a
+     *                 data structure holding an int.
+     *
+     *                 - The Caller bean calls the Callee Home create(...) method,
+     *                 passing this 'arg' object as an argument.
+     *
+     *                 - The Callee create(..) method modifies the value of the
+     *                 argument (should be a copy of 'arg')
+     *
+     *                 - When we return from the create method, the Caller check
+     *                 that the argument value is still set to the initial value.
+     *
+     *                 Remote interface arg semantics verif/loication: Same
+     *                 strategy but the Caller call a business method on the
+     *                 Callee remote interface.
      */
     @Test
-    public void constructortest1() throws Exception {
-        TEST_PROPS.setProperty(REQUEST,
-                "GET /servlet_jsh_sessioncookieconfig_web/TestServlet?testname=constructortest1 HTTP/1.1");
-        TEST_PROPS.setProperty(EXPECTED_HEADERS,
-                "Set-Cookie:" + "TCK_Cookie_Name=" + "##Expires="
-                        + "##Path=/servlet_jsh_sessioncookieconfig_web/TestServlet"
-                        + "##Secure");
-        TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, "Test FAILED");
-        invoke();
+    public void testStatefulRemote() throws Fault {
+        boolean pass;
+
+        try {
+            pass = bean.testStatefulRemote(props);
+        } catch (Exception e) {
+            throw new Fault("testStatefulRemote failed", e);
+        } finally {
+            if (null != bean) {
+                try {
+                    bean.cleanUpBean();
+                    bean.remove();
+                } catch (Exception e) {
+                    TestUtil.logErr("[Client] Ignoring Exception on " + "bean remove", e);
+                }
+            }
+        }
+
+        if (!pass) {
+            throw new Fault("testStatefulRemote failed");
+        }
+
     }
 
-    /*
-     * @testName: setNameTest
+    /**
+     * @testName: testStatefulLocal
      *
-     * @assertion_ids: Servlet:JAVADOC:744;
+     * @assertion_ids: EJB:SPEC:907.2; EJB:SPEC:1
      *
-     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn
-     * HttpSession on; Verify in servlet SessionCookieConfig.setName cannot be
-     * called once is set.
+     * @test_Strategy: This is applicable to : - a Session Stateful Callee bean
+     *                 defining a local client view only (No remote view).
+     *
+     *                 - a Stateless Caller bean, Calling this Callee Bean local
+     *                 home or local interface.
+     *
+     *                 We package in the same ejb-jar: - a Session Stateful Callee
+     *                 bean defining a local client view only (No remote view). -
+     *                 a Stateless Caller bean
+     *
+     *                 Local Home arg semantics verification:
+     *
+     *                 - We set a non-remote object 'arg' (of type SimpleArgument)
+     *                 to an initial value. This SimpleArgument class is just a
+     *                 data structure holding an int.
+     *
+     *                 - The Caller bean calls the Callee local home create(...)
+     *                 method, passing this 'arg' object as an argument.
+     *
+     *                 - The Callee create(..) method modifies the value of the
+     *                 argument (should be a reference to original 'arg')
+     *
+     *                 - When we return from the create method, the Caller check
+     *                 that the argument value is not set to the initial value,
+     *                 and reflect the changes made by the Callee.
+     *
+     *                 Local interface arg semantics verification:
+     *
+     *                 Same strategy but the Caller call a business method on the
+     *                 Callee local interface.
      */
     @Test
-    public void setNameTest() throws Exception {
-        TEST_PROPS.setProperty(APITEST, "setNameTest");
-        invoke();
+    public void testStatefulLocal() throws Fault {
+        boolean pass;
+
+        try {
+            pass = bean.testStatefulLocal(props);
+        } catch (Exception e) {
+            throw new Fault("testStatefulLocal failed", e);
+        } finally {
+            if (null != bean) {
+                try {
+                    bean.cleanUpBean();
+                    bean.remove();
+                } catch (Exception e) {
+                    TestUtil.logErr("[Client] Ignoring Exception on " + "bean remove", e);
+                }
+            }
+        }
+
+        if (!pass) {
+            throw new Fault("testStatefulLocal failed");
+        }
+
     }
 
-    /*
-     * @testName: setCommentTest
+    /**
+     * @testName: testStatefulBoth
      *
-     * @assertion_ids: Servlet:JAVADOC:740;
+     * @assertion_ids: EJB:SPEC:906; EJB:SPEC:907; EJB:SPEC:907.2
      *
-     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn
-     * HttpSession on; Verify in servlet SessionCookieConfig.setComment cannot be
-     * called once is set.
+     *
+     * @test_Strategy: This is applicable to :
+     *
+     *                 - a Session Stateful Callee bean defining a remote AND a
+     *                 local client view.
+     *
+     *                 - a Stateless Caller bean, Calling this Callee Bean home,
+     *                 local home, remote, or local interface.
+     *
+     *                 The test strategy is a cumulated version of the two
+     *                 previous tests ('testStatefulRemote' and
+     *                 'testStatefulLocal') on the Callee bean defining a local
+     *                 and a remote client view.
      */
     @Test
-    public void setCommentTest() throws Exception {
-        TEST_PROPS.setProperty(APITEST, "setCommentTest");
-        invoke();
+    public void testStatefulBoth() throws Fault {
+        boolean pass;
+
+        try {
+            pass = bean.testStatefulBoth(props);
+        } catch (Exception e) {
+            throw new Fault("testStatefulBoth failed", e);
+        } finally {
+            if (null != bean) {
+                try {
+                    bean.cleanUpBean();
+                    bean.remove();
+                } catch (Exception e) {
+                    TestUtil.logErr("[Client] Ignoring Exception on " + "bean remove", e);
+                }
+            }
+        }
+
+        if (!pass) {
+            throw new Fault("testStatefulBoth failed");
+        }
+
     }
 
-    /*
-     * @testName: setPathTest
+    /**
+     * @testName: testCMP20Remote
      *
-     * @assertion_ids: Servlet:JAVADOC:745;
+     * @assertion_ids: EJB:SPEC:906
      *
-     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn
-     * HttpSession on; Verify in servlet SessionCookieConfig.setPath cannot be
-     * called once is set.
+     * @test_Strategy:
+     *
+     *                 This is applicable to : - a CMP 2.0 Callee bean defining a
+     *                 remote client view only (No local view). - a Stateless
+     *                 Caller bean, Calling this CMP 2.0 Bean home or remote
+     *                 interface.
+     *
+     *                 We package in the same ejb-jar: - a CMP 2.0 Callee bean
+     *                 defining a remote client view only (No local view). - a
+     *                 Stateless Caller bean
+     *
+     *                 Remote Home arg semantics verification:
+     *
+     *                 - We set a non-remote object 'arg' (of type SimpleArgument)
+     *                 to an initial value. This SimpleArgument class is just a
+     *                 data structure holding an int.
+     *
+     *                 - The Caller bean calls the Callee Home create(...) method,
+     *                 passing this 'arg' object as an argument.
+     *
+     *                 - The Callee create(..) method modifies the value of the
+     *                 argument (should be a copy of 'arg')
+     *
+     *                 - When we return from the create method, the Caller check
+     *                 that the argument value is still set to the initial value.
+     *
+     *                 Remote interface arg semantics verification: Same strategy
+     *                 but the Caller call a business method on the Callee remote
+     *                 interface.
      */
     @Test
-    public void setPathTest() throws Exception {
-        TEST_PROPS.setProperty(APITEST, "setPathTest");
-        invoke();
+    public void testCMP20Remote() throws Fault {
+        boolean pass;
+
+        try {
+            pass = bean.testCMP20Remote(props);
+        } catch (Exception e) {
+            throw new Fault("testCMP20Remote failed", e);
+        } finally {
+            if (null != bean) {
+                try {
+                    bean.remove();
+                } catch (Exception e) {
+                    TestUtil.logErr("[Client] Ignoring Exception on " + "bean remove", e);
+                }
+            }
+        }
+
+        if (!pass) {
+            throw new Fault("testCMP20Remote failed");
+        }
+
     }
 
-    /*
-     * @testName: setDomainTest
+    /**
+     * @testName: testCMP20Local
      *
-     * @assertion_ids: Servlet:JAVADOC:741;
+     * @assertion_ids: EJB:SPEC:1; EJB:SPEC:907.2
      *
-     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn
-     * HttpSession on; Verify in servlet SessionCookieConfig.setDomain cannot be
-     * called once is set.
+     * @test_Strategy:
+     *
+     *                 This is applicable to : - a CMP 2.0 Callee bean defining a
+     *                 local client view only (No remote view).
+     *
+     *                 - a Stateless Caller bean, Calling this CMP 2.0 Bean local
+     *                 home or local interface.
+     *
+     *                 We package in the same ejb-jar:
+     *
+     *                 - a CMP 2.0 Callee bean defining a local client view only
+     *                 (No remote view).
+     *
+     *                 - a Stateless Caller bean
+     *
+     *                 Local Home arg semantics verification:
+     *
+     *                 - We set a non-remote object 'arg' (of type SimpleArgument)
+     *                 to an initial value. This SimpleArgument class is just a
+     *                 data structure holding an int.
+     *
+     *                 - The Caller bean calls the Callee local home create(...)
+     *                 method, passing this 'arg' object as an argument.
+     *
+     *                 - The Callee create(..) method modifies the value of the
+     *                 argument (should be a reference to original 'arg')
+     *
+     *                 - When we return from the create method, the Caller check
+     *                 that the argument value is not set to the initial value,
+     *                 and reflect the changes made by the Callee.
+     *
+     *                 Local interface arg semantics verification:
+     *
+     *                 Same strategy but the Caller call a business method on the
+     *                 Callee local interface.
      */
     @Test
-    public void setDomainTest() throws Exception {
-        TEST_PROPS.setProperty(APITEST, "setDomainTest");
-        invoke();
+    public void testCMP20Local() throws Fault {
+        boolean pass;
+
+        try {
+            pass = bean.testCMP20Local(props);
+        } catch (Exception e) {
+            throw new Fault("testCMP20Local failed", e);
+        } finally {
+            if (null != bean) {
+                try {
+                    bean.remove();
+                } catch (Exception e) {
+                    TestUtil.logErr("[Client] Ignoring Exception on " + "bean remove", e);
+                }
+            }
+        }
+
+        if (!pass) {
+            throw new Fault("testCMP20Local failed");
+        }
+
     }
 
-    /*
-     * @testName: setMaxAgeTest
+    /**
+     * @testName: testCMP20Both
      *
-     * @assertion_ids: Servlet:JAVADOC:743;
+     * @assertion_ids: EJB:SPEC:907; EJB:SPEC:907.1
      *
-     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn
-     * HttpSession on; Verify in servlet SessionCookieConfig.setMaxAge cannot be
-     * called once is set.
+     * @test_Strategy:
+     *
+     *                 This is applicable to :
+     *
+     *                 - a CMP 2.0 Callee bean defining a remote AND a local
+     *                 client view.
+     *
+     *                 - a Stateless Caller bean, Calling the CMP 2.0 Bean home,
+     *                 local home, remote, or local interface.
+     *
+     *                 The test strategy is a cumulated version of the two
+     *                 previous tests ('testCMP20Remote' and 'testCMP20Local') on
+     *                 the Callee bean defining a local and a remote client view.
      */
     @Test
-    public void setMaxAgeTest() throws Exception {
-        TEST_PROPS.setProperty(APITEST, "setMaxAgeTest");
-        invoke();
+    public void testCMP20Both() throws Fault {
+        boolean pass;
+
+        try {
+            pass = bean.testCMP20Both(props);
+        } catch (Exception e) {
+            throw new Fault("testCMP20Both failed", e);
+        } finally {
+            if (null != bean) {
+                try {
+                    bean.remove();
+                } catch (Exception e) {
+                    TestUtil.logErr("[Client] Ignoring Exception on " + "bean remove", e);
+                }
+            }
+        }
+
+        if (!pass) {
+            throw new Fault("testCMP20Both failed");
+        }
+
     }
 
-    /*
-     * @testName: setHttpOnlyTest
-     *
-     * @assertion_ids: Servlet:JAVADOC:742;
-     *
-     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn
-     * HttpSession on; Verify in servlet SessionCookieConfig.setHttpOnly cannot be
-     * called once is set.
-     */
-    @Test
-    public void setHttpOnlyTest() throws Exception {
-        TEST_PROPS.setProperty(APITEST, "setHttpOnlyTest");
-        invoke();
-    }
-
-    /*
-     * @testName: setSecureTest
-     *
-     * @assertion_ids: Servlet:JAVADOC:746;
-     *
-     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn
-     * HttpSession on; Verify in servlet SessionCookieConfig.setSecure cannot be
-     * called once is set.
-     */
-    @Test
-    public void setSecureTest() throws Exception {
-        TEST_PROPS.setProperty(APITEST, "setSecureTest");
-        invoke();
-    }
-
-    /*
-     * @testName: setAttributeTest
-     *
-     * @assertion_ids:
-     *
-     * @test_Strategy: Create a Servlet TestServlet, In the Servlet, turn
-     * HttpSession on; Verify in servlet SessionCookieConfig.setAttribute cannot be
-     * called once is set.
-     */
-    @Test
-    public void setAttributeTest() throws Exception {
-        TEST_PROPS.setProperty(APITEST, "setAttributeTest");
-        invoke();
+    public void cleanup() throws Fault {
+        logMsg("[Client] cleanup()");
     }
 }

--- a/tools/tck-rewrite/src/test/resources/logging.properties
+++ b/tools/tck-rewrite/src/test/resources/logging.properties
@@ -4,7 +4,7 @@ tck.jakarta.platform.rewrite.level = FINE
 
 java.util.logging.FileHandler.pattern = tools.log
 java.util.logging.FileHandler.level = FINEST
-java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
 
 # Limit the message that are printed on the console to INFO and above.
 java.util.logging.ConsoleHandler.level = INFO


### PR DESCRIPTION
I was testing against changes in the openrewrite maven plugin and found that the latest code requires the 8.7.x version of openrewrite core due to incompatible changes, so this updates to 8.7.2.
