### PR TITLE
Ensure that sigtest -IgnoreJDKClass can ignore JDK classes (java.* and javax.transaction.xa.*) during signature check

### DIFF
--- a/tools/sigtest/README.md
+++ b/tools/sigtest/README.md
@@ -1,7 +1,7 @@
 # SigTest
 
-**_NOTE:_**  This is a fork of the https://github.com/jtulach/netbeans-apitest project to allow for
-updates as needed by the Jakarta projects. The GAV for this fork has changed to:
+**_NOTE:_**  This is a fork of the https://github.com/jtulach/netbeans-apitest (which was a fork of the now archived OpenJDK https://github.com/openjdk/sigtest) project.  
+The purpose of this project is to allow for updates as needed by the Jakarta projects. The GAV for this fork has changed to:
 ```xml
 <dependency>
     <groupId>jakarta.tck</groupId>
@@ -12,10 +12,7 @@ updates as needed by the Jakarta projects. The GAV for this fork has changed to:
 
 *SigTest* is the tool for checking incompatibilities between different versions of the same API. 
 It is possible to use it as a Maven plugin or an Ant task to check for binary backward 
-compatibility and mutual signature compatibility. The tool is known to work with JDK8 and JDK11 and is used by many projects including [Graal](https://github.com/oracle/graal/commit/6ca3d0458d108ba183997f09fa51596fbe503893#diff-6229fdf88aa48f7dda4de6126283c913),
-[Hibernate](https://github.com/hibernate/hibernate-validator/pull/831/files), Apache [NetBeans](https://github.com/apache/incubator-netbeans/pull/670), and [Jakarta EE](https://jakarta.ee).
-
-[![Travis Status](https://travis-ci.org/jtulach/netbeans-apitest.svg?branch=master)](https://travis-ci.org/jtulach/netbeans-apitest)
+compatibility and mutual signature compatibility. The tool is known to work with JDK11+.
 
 ## Use in Maven
 
@@ -40,7 +37,7 @@ e.g. the signature file. Just add following into your own `pom.xml` file:
     </execution>
   </executions>
   <configuration>
-    <release>8</release> <!-- specify version of JDK API to use 8,11,...21 -->
+    <release>11</release> <!-- specify version of JDK API to use 11,...21 -->
     <packages>org.yourcompany.app.api,org.yourcompany.help.api</packages>
   </configuration>
 </plugin>
@@ -76,7 +73,7 @@ Try the following:
   <configuration>
     <packages>org.yourcompany.app.api,org.yourcompany.help.api</packages>
     <releaseVersion>1.3</releaseVersion>
-    <release>8</release> <!-- specify version of JDK API to use 6,7,8,...15 -->
+    <release>11</release> <!-- specify version of JDK API to use 11,...21 -->
   </configuration>
 </plugin>
 ```
@@ -139,7 +136,7 @@ then try:
  
     <packages>org.yourcompany.app.api,org.yourcompany.help.api</packages>
     <releaseVersion>1.3</releaseVersion>
-    <release>8</release> <!-- specify version of JDK API to use 6,7,8,...15 -->
+    <release>11</release> <!-- specify version of JDK API to use 11,...21 -->
   </configuration>
 ```
 
@@ -148,12 +145,12 @@ with the action option set to `strictcheck` the plugin will detect any API chang
 ## Relax verification of JDK signatures
 
 There are some cases where avoiding the verification of certain JDK classes entirely or their signatures can improve the ability to verify your API on different JDK versions.
-The `-IgnoreJDKClass` option can be used to ignore JDK java/javax.transaction.xa classes during signature verification checking when it comes to dealing with JDK 
-specific signature changes introduced by a later JDK version. As an example, a Signature file with @java.lang.Deprecated annotations from JDK8 may be seeing verification failures on JDK9+ 
+The `-IgnoreJDKClass` option can be used to ignore JDK java,* classes as well as javax.transaction.xa.* classes during signature verification checking which helps avoid failures caused by 
+JDK specific signature changes introduced by a later JDK version. As an example, a Signature file with @java.lang.Deprecated annotations from JDK8 may be seeing verification failures on JDK9+ 
 due to `default` fields being added to @Deprecated.  With `-IgnoreJDKClass specified, verification of the @Deprecated will only check that the tested class member has the 
 @Deprecated class but no verification of the @Deprecated signature will be performed. 
 
-Note that previous releases allowed a list JDK classes to ignore to be specified after the -IgnoreJDKClass option but that is no longer allowed.
+Note that previous releases allowed a list of JDK classes to be specified after the -IgnoreJDKClass option but that is no longer allowed.
 
 ### Specify JDK classes to ignore in Maven plugin
 Specify the `-IgnoreJDKClass` option as shown below:

--- a/tools/sigtest/README.md
+++ b/tools/sigtest/README.md
@@ -148,14 +148,15 @@ with the action option set to `strictcheck` the plugin will detect any API chang
 ## Relax verification of JDK signatures
 
 There are some cases where avoiding the verification of certain JDK classes entirely or their signatures can improve the ability to verify your API on different JDK versions.
-The `-IgnoreJDKClass` option can be used to specify a set of JDK classes that can benefit from relaxed signature verification rules when it comes to dealing with JDK 
+The `-IgnoreJDKClass` option can be used to ignore JDK java/javax.transaction.xa classes during signature verification checking when it comes to dealing with JDK 
 specific signature changes introduced by a later JDK version. As an example, a Signature file with @java.lang.Deprecated annotations from JDK8 may be seeing verification failures on JDK9+ 
-due to `default` fields being added to @Deprecated.  With `-IgnoreJDKClass java.lang.Deprecated` enabled, verification of the @Deprecated will only check that the tested class member has the 
+due to `default` fields being added to @Deprecated.  With `-IgnoreJDKClass specified, verification of the @Deprecated will only check that the tested class member has the 
 @Deprecated class but no verification of the @Deprecated signature will be performed. 
 
+Note that previous releases allowed a list JDK classes to ignore to be specified after the -IgnoreJDKClass option but that is no longer allowed.
+
 ### Specify JDK classes to ignore in Maven plugin
-To configure the JDK classes to pass to the sigtest engine with a `-IgnoreJDKClass` option, use the ignoreJDKClasses
-configuration element and provide the classes to ignore using the include element as shown here:
+Specify the `-IgnoreJDKClass` option as shown below:
 
 ```xml
   <configuration>
@@ -163,10 +164,7 @@ configuration element and provide the classes to ignore using the include elemen
  
     <packages>org.yourcompany.app.api,org.yourcompany.help.api</packages>
     <releaseVersion>1.3</releaseVersion>
-    <ignoreJDKClasses>
-      <include>java.lang.Deprecated</include>
-      <include>java.lang.Object</include>
-    </ignoreJDKClasses>
+    <ignoreJDKClasses/>
   </configuration>
 ```
 
@@ -177,8 +175,8 @@ but has been adopted to suite the needs of a [NetBeans project](http://wiki.netb
 Since then it evolved into [general purpose tool](http://wiki.netbeans.org/SigTest). When NetBeans become
 Apache project, Emilian Bold converted the [original Hg repository](http://hg.netbeans.org/apitest/) to
 [Git repository](https://github.com/emilianbold/netbeans-apitest) to preserve the history. The development,
-including support for JDK11, etc. now continues at following GitHub
-[repository](https://github.com/jtulach/netbeans-apitest/).
+including support for JDK11, etc. then moved to [repository](https://github.com/jtulach/netbeans-apitest/).
+This tool has been forked (yet again) now to the [github repository](https://github.com/eclipse-ee4j/jakartaee-tck-tools/tree/master/tools/sigtest)
 
 # License
 

--- a/tools/sigtest/README.md
+++ b/tools/sigtest/README.md
@@ -145,7 +145,7 @@ with the action option set to `strictcheck` the plugin will detect any API chang
 ## Relax verification of JDK signatures
 
 There are some cases where avoiding the verification of certain JDK classes entirely or their signatures can improve the ability to verify your API on different JDK versions.
-The `-IgnoreJDKClass` option can be used to ignore JDK java,* classes as well as javax.transaction.xa.* classes during signature verification checking which helps avoid failures caused by 
+The `-IgnoreJDKClass` option will ignore (all) JDK java.* and javax.* classes during signature verification checking which helps avoid failures caused by 
 JDK specific signature changes introduced by a later JDK version. As an example, a Signature file with @java.lang.Deprecated annotations from JDK8 may be seeing verification failures on JDK9+ 
 due to `default` fields being added to @Deprecated.  With `-IgnoreJDKClass specified, verification of the @Deprecated will only check that the tested class member has the 
 @Deprecated class but no verification of the @Deprecated signature will be performed. 

--- a/tools/sigtest/pom.xml
+++ b/tools/sigtest/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>sigtest-maven-plugin</artifactId>
-    <version>2.2</version>
+    <version>2.3-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>API Signature Test Plugin</name>
     <url>https://github.com/eclipse-ee4j/jakartaee-tck-tools/wiki</url>
@@ -216,10 +216,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+	<dependency>
+	    <groupId>org.junit.jupiter</groupId>
+	    <artifactId>junit-jupiter-engine</artifactId>
+	    <version>5.10.2</version>
+	    <scope>test</scope>
+        </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -285,6 +291,21 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>jakarta.tck</groupId>
+                        <artifactId>sigtest-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                            <goals>
+                                <goal>generate</goal>
+                            </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <release>17</release> <!-- specify version of JDK API to use -->
+                            <packages>com.sun.tdk.signaturetest.classpath</packages>
+                        </configuration>
+                        </plugin>
                 </plugins>
             </build>
 

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/Merge.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/Merge.java
@@ -214,7 +214,7 @@ public class Merge extends SigTest implements Log {
                 try {
                     if (in.isFeatureSupported(FeaturesHolder.BuildMembers))
                         builder.createMembers(c, true, true, false);
-                    normalizer.normThrows(c, true);
+                    normalizer.normThrows(c, true, false);
                 } catch (ClassNotFoundException e) {
                     //storeError(i18n.getString("Setup.error.message.classnotfound", e.getMessage()));
                 }
@@ -240,7 +240,7 @@ public class Merge extends SigTest implements Log {
             ClassDescription c = (ClassDescription) i.next();
             try {
                 builder.createMembers(c, false, true, false);
-                normalizer.normThrows(c, true);
+                normalizer.normThrows(c, true, false);
             } catch (ClassNotFoundException e) {
                 storeError(i18n.getString("Merge.warning.message.classnotfound", e.getMessage()), null);
             }

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/Setup.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/Setup.java
@@ -228,6 +228,7 @@ public class Setup extends SigTest {
 
         parser.addOption(ERRORALL_OPTION, OptionInfo.optionalFlag(), optionsDecoder);
 
+        parser.addOption(EXCLUDE_JDK_CLASS_OPTION, OptionInfo.optionalFlag(), optionsDecoder);
         try {
             parser.processArgs(args);
         }
@@ -481,7 +482,7 @@ public class Setup extends SigTest {
 
                 try {
                     testableMCBuilder.createMembers(c, addInherited(), true, false);
-                    normalizer.normThrows(c, true);
+                    normalizer.normThrows(c, true, false);
                     removeUndocumentedAnnotations(c, testableHierarchy);
                 } catch (ClassNotFoundException e) {
                     if (SigTest.debug) {

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/SetupAndTest.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/SetupAndTest.java
@@ -84,6 +84,7 @@ public class SetupAndTest extends Result {
 
         parser.addOption(SigTest.PACKAGE_OPTION, OptionInfo.optionVariableParams(1, OptionInfo.UNLIMITED), optionsDecoder);
         parser.addOption(SigTest.FILENAME_OPTION, OptionInfo.option(1), optionsDecoder);
+        parser.addOption(SigTest.EXCLUDE_JDK_CLASS_OPTION, OptionInfo.optionalFlag(), optionsDecoder);
 
         parser.addOption(SigTest.WITHOUTSUBPACKAGES_OPTION, OptionInfo.optionVariableParams(1, OptionInfo.UNLIMITED), optionsDecoder);
         parser.addOption(SigTest.EXCLUDE_OPTION, OptionInfo.optionVariableParams(1, OptionInfo.UNLIMITED), optionsDecoder);
@@ -174,6 +175,8 @@ public class SetupAndTest extends Result {
             addOption(setupOptions, SigTest.CLASSPATH_OPTION, args[0]);
         } else if (optionName.equalsIgnoreCase(TEST_OPTION)) {
             addOption(testOptions, SigTest.CLASSPATH_OPTION, args[0]);
+        } else if (optionName.equalsIgnoreCase(SigTest.EXCLUDE_JDK_CLASS_OPTION)) {
+            addFlag(testOptions, SigTest.EXCLUDE_JDK_CLASS_OPTION);
         } else if (optionName.equalsIgnoreCase(SigTest.FILENAME_OPTION) ||
                 optionName.equalsIgnoreCase(SigTest.PACKAGE_OPTION) ||
                 optionName.equalsIgnoreCase(SigTest.WITHOUTSUBPACKAGES_OPTION) ||

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/SigTest.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/SigTest.java
@@ -40,6 +40,7 @@ import com.sun.tdk.signaturetest.sigfile.Format;
 import com.sun.tdk.signaturetest.util.CommandLineParser;
 import com.sun.tdk.signaturetest.util.CommandLineParserException;
 import com.sun.tdk.signaturetest.util.I18NResourceBundle;
+import com.sun.tdk.signaturetest.util.OptionInfo;
 
 import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
@@ -103,7 +104,7 @@ public abstract class SigTest extends Result implements PluginAPI, Log {
     public static final String TESTURL_OPTION = "-TestURL";
     public static final String PLUGIN_OPTION = "-Plugin";
     public static final String ERRORALL_OPTION = "-ErrorAll";
-
+    public static final String EXCLUDE_JDK_CLASS_OPTION = "-IgnoreJDKClass";
 
     private static I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(SigTest.class);
 
@@ -284,6 +285,8 @@ public abstract class SigTest extends Result implements PluginAPI, Log {
             excludedPackages.addPackages(CommandLineParser.parseListOption(args));
         } else if (optionName.equalsIgnoreCase(CLASSPATH_OPTION)) {
             classpathStr = args[0];
+        } else if (optionName.equalsIgnoreCase(EXCLUDE_JDK_CLASS_OPTION)) {
+                JDKExclude.enable();
         } else if (optionName.equalsIgnoreCase(USE_BOOT_CP)) {
             if (args.length == 0) {
                 release = Release.BOOT_CLASS_PATH;

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/SignatureTest.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/SignatureTest.java
@@ -1442,24 +1442,24 @@ public class SignatureTest extends SigTest {
 
         while ((requiredPos < bl) && (foundPos < tl)) {
             int comp = 0;
-            if (JDKExclude.isJdkClass(baseAnnotList[requiredPos].getName()) ||
-                    JDKExclude.isJdkClass(testAnnotList[foundPos].getName())) {
-                // don't check excluded Annotation classes
-                return;
+            boolean isJDKExcludedClass = (JDKExclude.isJdkClass(baseAnnotList[requiredPos].getName()) ||
+                    JDKExclude.isJdkClass(testAnnotList[foundPos].getName()));
+            if (isJDKExcludedClass) {
+                // do comparison with just the JDK annotation name
+                comp = baseAnnotList[requiredPos].getName().compareTo(testAnnotList[foundPos].getName());
+            } else {
+                comp = baseAnnotList[requiredPos].compareTo(testAnnotList[foundPos]);
             }
-            comp = baseAnnotList[requiredPos].compareTo(testAnnotList[foundPos]);
 
             if (comp < 0) {
                 reportError(required, baseAnnotList[requiredPos].toString(), false);
                 requiredPos++;
+            } else if (comp > 0) {
+                reportError(found, testAnnotList[foundPos].toString(), true);
+                foundPos++;
             } else {
-                if (comp > 0) {
-                    reportError(found, testAnnotList[foundPos].toString(), true);
-                    foundPos++;
-                } else {
-                    foundPos++;
-                    requiredPos++;
-                }
+                foundPos++;
+                requiredPos++;
             }
         }
         while (requiredPos < bl) {

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/SignatureTest.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/SignatureTest.java
@@ -168,7 +168,6 @@ public class SignatureTest extends SigTest {
     public static final String NOMERGE_OPTION = "-NoMerge";
     public static final String WRITE_OPTION = "-Write";
     public static final String UPDATE_FILE_OPTION = "-Update";
-    public static final String EXCLUDE_JDK_CLASS_OPTION = "-IgnoreJDKClass";
 
     private String logName = null;
     private String outFormat = null;
@@ -242,14 +241,9 @@ public class SignatureTest extends SigTest {
 
     protected Exclude exclude;
     private int readMode = MultipleFileReader.MERGE_MODE;
-    private JDKExclude jdkExclude = new DefaultJDKExclude();
-    /**
-     * List of names of JDK classes and/or packages to be ignored along with subpackages. 
-     */
-    private static PackageGroup excludedJdkClasses = new PackageGroup(true);
-    
+
     public SignatureTest() {
-        normalizer = new ThrowsNormalizer(jdkExclude); 
+        normalizer = new ThrowsNormalizer();
     }
 
     /**
@@ -384,7 +378,7 @@ public class SignatureTest extends SigTest {
         parser.addOption(UPDATE_FILE_OPTION, OptionInfo.option(1), optionsDecoder);
         parser.addOption(MODE_OPTION, OptionInfo.option(1), optionsDecoder);
         parser.addOption(ALLPUBLIC_OPTION, OptionInfo.optionalFlag(), optionsDecoder);
-        parser.addOption(EXCLUDE_JDK_CLASS_OPTION, OptionInfo.optionVariableParams(1, OptionInfo.UNLIMITED), optionsDecoder);
+        parser.addOption(EXCLUDE_JDK_CLASS_OPTION,OptionInfo.optionalFlag(), optionsDecoder);
         
         parser.addOption(VERBOSE_OPTION, OptionInfo.optionalFlag(), optionsDecoder);
 
@@ -506,7 +500,7 @@ public class SignatureTest extends SigTest {
         } else if (optionName.equalsIgnoreCase(NOMERGE_OPTION)) {
             readMode = MultipleFileReader.CLASSPATH_MODE;
         } else if (optionName.equalsIgnoreCase(EXCLUDE_JDK_CLASS_OPTION)) {
-            excludedJdkClasses.addPackages(CommandLineParser.parseListOption(args));
+            JDKExclude.enable();
         } else {
             super.decodeCommonOptions(optionName, args);
         }
@@ -723,7 +717,7 @@ public class SignatureTest extends SigTest {
 
         testableHierarchy = new ClassHierarchyImpl(loader, trackMode);
 
-        testableMCBuilder = new MemberCollectionBuilder(this, jdkExclude);
+        testableMCBuilder = new MemberCollectionBuilder(this);
 
         signatureClassesHierarchy = new ClassHierarchyImpl(in, trackMode);
 
@@ -744,7 +738,7 @@ public class SignatureTest extends SigTest {
         boolean buildMembers = in.isFeatureSupported(FeaturesHolder.BuildMembers);
         MemberCollectionBuilder sigfileMCBuilder = null;
         if (buildMembers) {
-            sigfileMCBuilder = new MemberCollectionBuilder(this, jdkExclude);
+            sigfileMCBuilder = new MemberCollectionBuilder(this);
         }
 
         //  Reading the sigfile: main loop.
@@ -1040,7 +1034,11 @@ public class SignatureTest extends SigTest {
                     required.removeThrows();
                     found.removeThrows();
                 } else {
-                    normalizer.normThrows(found, true);
+                    // "required" are based on the predefined signatures file(s).
+                    // Make a small change on "required" to not include "throws" of any JDK classes
+                    normalizer.normThrows(required, true, true);
+                    // "found" are based on implementation classes descriptions read into memory
+                    normalizer.normThrows(found, true, false);
                 }
 
                 if (useErasurator()) {
@@ -1402,7 +1400,7 @@ public class SignatureTest extends SigTest {
             }
         }
 
-        if (!isSupersettingEnabled && found != null && !jdkExclude.isJdkClass(found.getDeclaringClassName())) {
+        if (!isSupersettingEnabled && found != null && !JDKExclude.isJdkClass(found.getDeclaringClassName())) {
             errorManager.addError(MessageType.getAddedMessageType(found.getMemberType()), name, found.getMemberType(), found.toString(), found);
             if (logger.isLoggable(Level.FINE)) {
                 logger.fine("added :-( " + found);
@@ -1411,16 +1409,16 @@ public class SignatureTest extends SigTest {
     }
 
 
-    private void checkAnnotations(MemberDescription base, MemberDescription test) {
+    private void checkAnnotations(MemberDescription required, MemberDescription found) {
 
         if (!isTigerFeaturesTracked)
             return;
 
-        AnnotationItem[] baseAnnotList = base == null ? AnnotationItem.EMPTY_ANNOTATIONITEM_ARRAY :
-                removeUndocumentedAnnotations(base.getAnnoList(), signatureClassesHierarchy);
+        AnnotationItem[] baseAnnotList = required == null ? AnnotationItem.EMPTY_ANNOTATIONITEM_ARRAY :
+                removeUndocumentedAnnotations(required.getAnnoList(), signatureClassesHierarchy);
 
-        AnnotationItem[] testAnnotList = test == null ? AnnotationItem.EMPTY_ANNOTATIONITEM_ARRAY :
-                removeUndocumentedAnnotations(test.getAnnoList(), testableHierarchy);
+        AnnotationItem[] testAnnotList = found == null ? AnnotationItem.EMPTY_ANNOTATIONITEM_ARRAY :
+                removeUndocumentedAnnotations(found.getAnnoList(), testableHierarchy);
 
         // RI JSR 308 doesn't support reflection yet
         if (!isStatic) {
@@ -1434,45 +1432,43 @@ public class SignatureTest extends SigTest {
 
         int bl = baseAnnotList.length;
         int tl = testAnnotList.length;
-        int bPos = 0;
-        int tPos = 0;
+        int requiredPos = 0;
+        int foundPos = 0;
 
-        if (base != null && jdkExclude.isJdkClass(base.getDeclaringClassName())) {
+        if (required != null && JDKExclude.isJdkClass(required.getDeclaringClassName())) {
+            // don't check excluded Annotation classes
             return;
         }
 
-        if (test != null && jdkExclude.isJdkClass(test.getDeclaringClassName())) {
-            return;
-        }
-
-        while ((bPos < bl) && (tPos < tl)) {
+        while ((requiredPos < bl) && (foundPos < tl)) {
             int comp = 0;
-            if (jdkExclude.isJdkClass(baseAnnotList[bPos].getName()) || 
-                    jdkExclude.isJdkClass(testAnnotList[tPos].getName())) {
-                comp = baseAnnotList[bPos].getName().compareTo(testAnnotList[tPos].getName());
-            } else {
-                comp = baseAnnotList[bPos].compareTo(testAnnotList[tPos]);
+            if (JDKExclude.isJdkClass(baseAnnotList[requiredPos].getName()) ||
+                    JDKExclude.isJdkClass(testAnnotList[foundPos].getName())) {
+                // don't check excluded Annotation classes
+                return;
             }
+            comp = baseAnnotList[requiredPos].compareTo(testAnnotList[foundPos]);
+
             if (comp < 0) {
-                reportError(base, baseAnnotList[bPos].toString(), false);
-                bPos++;
+                reportError(required, baseAnnotList[requiredPos].toString(), false);
+                requiredPos++;
             } else {
                 if (comp > 0) {
-                    reportError(test, testAnnotList[tPos].toString(), true);
-                    tPos++;
+                    reportError(found, testAnnotList[foundPos].toString(), true);
+                    foundPos++;
                 } else {
-                    tPos++;
-                    bPos++;
+                    foundPos++;
+                    requiredPos++;
                 }
             }
         }
-        while (bPos < bl) {
-            reportError(base, baseAnnotList[bPos].toString(), false);
-            bPos++;
+        while (requiredPos < bl) {
+            reportError(required, baseAnnotList[requiredPos].toString(), false);
+            requiredPos++;
         }
-        while (tPos < tl) {
-            reportError(test, testAnnotList[tPos].toString(), true);
-            tPos++;
+        while (foundPos < tl) {
+            reportError(found, testAnnotList[foundPos].toString(), true);
+            foundPos++;
         }
     }
 
@@ -1566,14 +1562,5 @@ public class SignatureTest extends SigTest {
             return null;
         }
 
-    }
-
-    static class DefaultJDKExclude implements JDKExclude {
-
-        @Override
-        public boolean isJdkClass(String name) {
-            return name != null && 
-                    excludedJdkClasses.checkName(name);
-        }
     }
 }

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/ClassCorrector.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/ClassCorrector.java
@@ -56,12 +56,6 @@ public class ClassCorrector implements Transformer {
 
     protected ClassHierarchy classHierarchy = null;
     private Log log;
-    private JDKExclude jdkExclude = new JDKExclude() {
-        @Override
-        public boolean isJdkClass(String name) {
-            return false;
-        }
-    };
 
     /**
      * Selftracing can be turned on by setting FINER level
@@ -82,25 +76,13 @@ public class ClassCorrector implements Transformer {
 
 
     private static I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(ClassCorrector.class);
-
-    public ClassCorrector(Log log, JDKExclude jdkExclude) {
-        this.jdkExclude = jdkExclude != null ? jdkExclude :
-                new JDKExclude() {
-                    @Override
-                    public boolean isJdkClass(String name) {
-                        return false;
-                    }
-                };
+    
+    public ClassCorrector(Log log) {
         this.log = log;
         // not configured externally
         if(logger.getLevel() == null) {
             logger.setLevel(Level.OFF);
         }
-        
-    }
-    
-    public ClassCorrector(Log log) {
-        this(log, null);
     }
 
 
@@ -198,7 +180,7 @@ public class ClassCorrector implements Transformer {
                 } else
                     exceptionName = throwables.substring(startPos);
 
-                if (!jdkExclude.isJdkClass(exceptionName) && isInvisibleClass(exceptionName)) {
+                if (!JDKExclude.isJdkClass(exceptionName) && isInvisibleClass(exceptionName)) {
                     List supers = classHierarchy.getSuperClasses(exceptionName);
                     exceptionName = findVisibleReplacement(exceptionName, supers, "java.lang.Throwable", true);
                     mustCorrect = true;
@@ -718,7 +700,7 @@ public class ClassCorrector implements Transformer {
 
         if (fqname.startsWith("?"))
             return false;
-        if (jdkExclude.isJdkClass(fqname)) 
+        if (JDKExclude.isJdkClass(fqname))
             return false;
         String pname = ClassCorrector.stripArrays(ClassCorrector.stripGenerics(fqname));
 

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/JDKExclude.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/JDKExclude.java
@@ -27,18 +27,30 @@
 
 package com.sun.tdk.signaturetest.core;
 
+import com.sun.tdk.signaturetest.util.CommandLineParser;
+
 /**
  * JDKExclude represents the JDK classes to be excluded from signature testing.
  *
  * @author Scott Marlow
  */
-public interface JDKExclude {
+public class JDKExclude {
+
+    private static PackageGroup excludedJdkClasses = new PackageGroup(true);
+
+    public static void enable() {
+        excludedJdkClasses.addPackages(new String[] {"java", "javax.transaction.xa" });
+    }
 
     /**
      * Check for JDK classes that should be excluded from signature testing.
      * @param name is class name (with typical dot separators) to check.
      * @return true if the class should be excluded from signature testing.
      */
-    boolean isJdkClass(String name);
-   
+    public static boolean isJdkClass(String name) {
+        return name != null &&
+                excludedJdkClasses.checkName(name);
+
+    }
+
 }

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/JDKExclude.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/JDKExclude.java
@@ -27,8 +27,6 @@
 
 package com.sun.tdk.signaturetest.core;
 
-import com.sun.tdk.signaturetest.util.CommandLineParser;
-
 /**
  * JDKExclude represents the JDK classes to be excluded from signature testing.
  *
@@ -39,7 +37,7 @@ public class JDKExclude {
     private static PackageGroup excludedJdkClasses = new PackageGroup(true);
 
     public static void enable() {
-        excludedJdkClasses.addPackages(new String[] {"java", "javax.transaction.xa" });
+        excludedJdkClasses.addPackages(new String[] {"java", "javax" });
     }
 
     /**

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/MemberCollectionBuilder.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/MemberCollectionBuilder.java
@@ -76,16 +76,6 @@ public class MemberCollectionBuilder {
      */
     static Logger logger = Logger.getLogger(MemberCollectionBuilder.class.getName());
 
-    public MemberCollectionBuilder(Log log, JDKExclude jdkExclude) {
-        this.cc = jdkExclude == null ? new ClassCorrector(log) : new ClassCorrector(log, jdkExclude);
-        this.log = log;
-
-        // not configured externally
-        if (logger.getLevel() == null) {
-            logger.setLevel(Level.OFF);
-        }
-    }
-    
     public MemberCollectionBuilder(Log log) {
         this.cc = new ClassCorrector(log);
         this.log = log;

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/Sigtest.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/Sigtest.java
@@ -48,6 +48,8 @@ public final class Sigtest extends Task {
     String failureProperty;
     String release;
 
+    Boolean jdkExcludeEnabled = Boolean.FALSE;
+
     public void setFileName(File f) {
         fileName = f;
     }
@@ -175,8 +177,8 @@ public final class Sigtest extends Task {
             }
 
             @Override
-            protected String[] getIgnoreJDKClassEntries() {
-                return null;
+            protected boolean isJDKExcludeEnabled() {
+                return jdkExcludeEnabled.booleanValue();
             }
         };
         int returnCode;

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCheck.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCheck.java
@@ -98,16 +98,13 @@ public final class SigtestCheck extends AbstractMojo {
     private File report;
     @Parameter(defaultValue = "true", property = "sigtest.fail")
     private boolean failOnError;
-    /**
-     * ignore JDK classes entries
-     */
-    @Parameter
-    private String[] ignoreJDKClasses;
+    @Parameter(defaultValue = "false", property = "IgnoreJDKClass.")
+    private boolean ignoreJDKClass;
 
     public SigtestCheck() {
     }
 
-    SigtestCheck(MavenProject prj, File classes, File sigfile, String action, String packages, File report, boolean failOnError) {
+    SigtestCheck(MavenProject prj, File classes, File sigfile, String action, String packages, File report, boolean failOnError, boolean ignoreJDKClass) {
         this.prj = prj;
         this.classes = classes;
         this.sigfile = sigfile;
@@ -115,6 +112,7 @@ public final class SigtestCheck extends AbstractMojo {
         this.packages = packages;
         this.report = report;
         this.failOnError = failOnError;
+        this.ignoreJDKClass = ignoreJDKClass;
     }
 
 
@@ -192,8 +190,8 @@ public final class SigtestCheck extends AbstractMojo {
             }
 
             @Override
-            protected String[] getIgnoreJDKClassEntries() {
-                return ignoreJDKClasses;
+            protected boolean isJDKExcludeEnabled() {
+                return ignoreJDKClass;
             }
         };
         try {

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCompare.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCompare.java
@@ -74,6 +74,9 @@ public final class SigtestCompare extends AbstractMojo {
     private File report;
     @Parameter(defaultValue = "true", property = "sigtest.fail")
     private boolean failOnError;
+    @Parameter(defaultValue = "false", property = "IgnoreJDKClass.")
+    private boolean ignoreJDKClass;
+
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (packages == null) {
@@ -94,10 +97,10 @@ public final class SigtestCompare extends AbstractMojo {
             throw new MojoExecutionException("Cannot resolve " + artifact, ex);
         }
 
-        SigtestGenerate generate = new SigtestGenerate(prj, artifact.getFile(), sigfile, packages, releaseVersion, release);
+        SigtestGenerate generate = new SigtestGenerate(prj, artifact.getFile(), sigfile, packages, releaseVersion, release, ignoreJDKClass);
         generate.execute();
 
-        SigtestCheck check = new SigtestCheck(prj, classes, sigfile, action, packages, report, failOnError);
+        SigtestCheck check = new SigtestCheck(prj, classes, sigfile, action, packages, report, failOnError, ignoreJDKClass);
         check.execute();
     }
 }

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestGenerate.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestGenerate.java
@@ -84,24 +84,21 @@ public final class SigtestGenerate extends AbstractMojo {
     @Parameter(defaultValue = "true")
     private boolean attach;
     
-    /**
-     * ignore JDK classes entries
-     */
-    @Parameter
-    private String[] ignoreJDKClasses;
-
     private String version;
+
+    private boolean ignoreJDKClass;
 
     public SigtestGenerate() {
     }
 
-    SigtestGenerate(MavenProject prj, File classes, File sigfile, String packages, String version, String release) {
+    SigtestGenerate(MavenProject prj, File classes, File sigfile, String packages, String version, String release, boolean ignoreJDKClass) {
         this.prj = prj;
         this.classes = classes;
         this.sigfile = sigfile;
         this.packages = packages;
         this.version = version;
         this.release = release;
+        this.ignoreJDKClass = ignoreJDKClass;
     }
 
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -172,8 +169,8 @@ public final class SigtestGenerate extends AbstractMojo {
             }
             
             @Override
-            protected String[] getIgnoreJDKClassEntries() {
-                return ignoreJDKClasses;
+            protected boolean isJDKExcludeEnabled() {
+                return ignoreJDKClass;
             }
         };
         try {

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestHandler.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestHandler.java
@@ -96,12 +96,8 @@ abstract class SigtestHandler {
             arg.add("-ApiVersion");
             arg.add(getVersion());
         }
-        final String[] ignoreJdkClassEntries = getIgnoreJDKClassEntries();
-        if (ignoreJdkClassEntries != null) {
-            for (String ignore : ignoreJdkClassEntries) {
-                arg.add("-IgnoreJDKClass");
-                arg.add(ignore);
-            }
+        if (isJDKExcludeEnabled()) {
+            arg.add("-IgnoreJDKClass");
         }
 
         logInfo("Packages: " + getPackages());
@@ -266,7 +262,7 @@ abstract class SigtestHandler {
     protected abstract File getReport();
     protected abstract String getMail();
     protected abstract Boolean isFailOnError();
-    protected abstract String[] getIgnoreJDKClassEntries();
+    protected abstract boolean isJDKExcludeEnabled();
     protected abstract void logInfo(String message);
     protected abstract void logError(String message);
 }


### PR DESCRIPTION
Work in progress for https://github.com/eclipse-ee4j/jakartaee-tck-tools/issues/20.  This change eliminates the need for passing the often changing list JDK classes to exclude.  Instead just set -IgnoreJDKClass
