### PR TITLE
Restore build version information

### DIFF
--- a/tools/sigtest/pom.xml
+++ b/tools/sigtest/pom.xml
@@ -32,6 +32,8 @@
         <!-- Require a Java 17 for testing and compiling -->
         <maven.compiler.testRelease>17</maven.compiler.testRelease>
         <jdk.min.version>${maven.compiler.testRelease}</jdk.min.version>
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
+        <skipITs>false</skipITs>
     </properties>
     <build>
         <plugins>
@@ -163,7 +165,49 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Manifest-Version>1.0</Manifest-Version>
+                            <Main-Class>com.sun.tdk.signaturetest.Main</Main-Class>
+                            <Implementation-Title>Jakarta TCK Tools SigTest</Implementation-Title>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                            <Implementation-Vendor>${user.name}</Implementation-Vendor>
+                            <Implementation-Build-Time>${maven.build.timestamp}</Implementation-Build-Time>
+                            <Implementation-Build-OS>${os.name} ${os.version}</Implementation-Build-OS>
+                            <!-- Add more entries as needed -->
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.2.5</version>
+                <executions>
+                    <execution>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipITs>${skipITs}</skipITs>
+                </configuration>
+            </plugin>
         </plugins>
+
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
     </build>
     <dependencies>
         <dependency>
@@ -243,85 +287,5 @@
             <type>jar</type>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-release-plugin</artifactId>
-                        <inherited>true</inherited>
-                        <configuration>
-                            <autoVersionSubmodules>true</autoVersionSubmodules>
-                            <pushChanges>false</pushChanges>
-                            <localCheckout>true</localCheckout>
-                            <preparationGoals>clean install</preparationGoals>
-                            <releaseProfiles>gpg-sign,jboss-release</releaseProfiles>
-                            <tagNameFormat>@{project.version}</tagNameFormat>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
-                            <docletArtifact>
-                                <groupId>nl.talsmasoftware</groupId>
-                                <artifactId>umldoclet</artifactId>
-                                <version>2.0.18</version>
-                            </docletArtifact>
-                            <useStandardDocletOptions>true</useStandardDocletOptions>
-                            <charset>UTF-8</charset>
-                            <encoding>UTF-8</encoding>
-                            <docencoding>UTF-8</docencoding>
-                            <breakiterator>true</breakiterator>
-                            <version>true</version>
-                            <author>true</author>
-                            <keywords>true</keywords>
-                            <additionalOptions>
-                                <additionalOption>-sourceclasspath ${project.build.outputDirectory}</additionalOption>
-                            </additionalOptions>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>jakarta.tck</groupId>
-                        <artifactId>sigtest-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                            <goals>
-                                <goal>generate</goal>
-                            </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <release>17</release> <!-- specify version of JDK API to use -->
-                            <packages>com.sun.tdk.signaturetest.classpath</packages>
-                        </configuration>
-                        </plugin>
-                </plugins>
-            </build>
-
-            <distributionManagement>
-                <repository>
-                    <id>${jboss.releases.repo.id}</id>
-                    <name>JBoss Releases Repository</name>
-                    <url>${jboss.releases.repo.url}</url>
-                </repository>
-                <snapshotRepository>
-                    <id>${jboss.snapshots.repo.id}</id>
-                    <name>JBoss Snapshots Repository</name>
-                    <url>${jboss.snapshots.repo.url}</url>
-                </snapshotRepository>
-            </distributionManagement>
-        </profile>
-    </profiles>
 
 </project>

--- a/tools/sigtest/pom.xml
+++ b/tools/sigtest/pom.xml
@@ -32,7 +32,6 @@
         <!-- Require a Java 17 for testing and compiling -->
         <maven.compiler.testRelease>17</maven.compiler.testRelease>
         <jdk.min.version>${maven.compiler.testRelease}</jdk.min.version>
-        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
         <skipITs>false</skipITs>
     </properties>
     <build>
@@ -166,6 +165,44 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>8.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                    <!-- generate the git.properties file -->
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/META-INF/git.properties</generateGitPropertiesFilename>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <files>
+                                <file>${project.build.outputDirectory}/META-INF/git.properties</file>
+                            </files>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>
@@ -176,8 +213,9 @@
                             <Main-Class>com.sun.tdk.signaturetest.Main</Main-Class>
                             <Implementation-Title>Jakarta TCK Tools SigTest</Implementation-Title>
                             <Implementation-Version>${project.version}</Implementation-Version>
-                            <Implementation-Vendor>${user.name}</Implementation-Vendor>
-                            <Implementation-Build-Time>${maven.build.timestamp}</Implementation-Build-Time>
+                            <Implementation-Vendor>Jakarta Eclipse WG</Implementation-Vendor>
+                            <!--suppress UnresolvedMavenProperty; comes from target/classes/META-INF/git.properties -->
+                            <Implementation-Build-Time>${git.commit.id.full}</Implementation-Build-Time>
                             <Implementation-Build-OS>${os.name} ${os.version}</Implementation-Build-OS>
                             <!-- Add more entries as needed -->
                         </manifestEntries>

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/Version.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/Version.java
@@ -29,16 +29,82 @@ package com.sun.tdk.signaturetest;
 
 import com.sun.tdk.signaturetest.util.I18NResourceBundle;
 
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
 public class Version {
 
     private static I18NResourceBundle i18n =
             I18NResourceBundle.getBundleForClass(Version.class);
 
-    // the following constatnts should be filled in by the build script
-    public static final String Number="2.2";
-    public static final String build_time="";
-    public static final String build_os="";
-    public static final String build_user="";
+    // the following constants should be filled in by the build script
+    public static final String Number;
+    public static final String build_time;
+    public static final String build_os;
+    public static final String build_user;
+
+    public static final String IMPLEMENTATION_BUILD_OS = "Implementation-Build-OS";
+
+    public static final String IMPLEMENTATION_BUILD_TIME = "Implementation-Build-Time";
+
+    static {
+        // Defaults
+        String number = "Unknown";
+        String buildOS = System.getProperty("os.name") + " " + System.getProperty("os.version");
+        String buildUser = System.getProperty("user.name");
+        ZonedDateTime gmt = ZonedDateTime.now(ZoneId.of("GMT"));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        String buildTime = gmt.format(formatter);
+        // Look for build info from the jar manifest
+        try {
+            // Get the URL of the jar file from the CodeSource
+            ProtectionDomain pd = Version.class.getProtectionDomain();
+            CodeSource cs = pd.getCodeSource();
+            URL url = cs.getLocation();
+            // Open a JarURLConnection to the jar file's URL
+            if(url.getProtocol().equals("file")) {
+                // If the URL is a file URL, convert it to a jar URL if it is actually a jar file
+                String path = url.getPath();
+                if(path.endsWith(".jar")) {
+                    url = new URL("jar:file:" + path + "!/");
+                } else {
+                    throw new IllegalStateException(String.format("Warning: %s is not a jar file\n", path));
+                }
+            }
+            JarURLConnection jarConnection = (JarURLConnection) url.openConnection();
+            // Get the Manifest from the JarURLConnection
+            Manifest mf = jarConnection.getManifest();
+            // Read the attributes from the Manifest
+            Attributes attrs = mf.getMainAttributes();
+            if(attrs.containsKey(Attributes.Name.IMPLEMENTATION_VERSION)) {
+                number = attrs.getValue(Attributes.Name.IMPLEMENTATION_VERSION);
+            }
+            if(attrs.containsKey(Attributes.Name.IMPLEMENTATION_VENDOR)) {
+                buildUser = attrs.getValue(Attributes.Name.IMPLEMENTATION_VENDOR);
+            }
+            if(attrs.containsKey(IMPLEMENTATION_BUILD_OS)) {
+                buildOS = attrs.getValue(IMPLEMENTATION_BUILD_OS);
+            }
+            if(attrs.containsKey(IMPLEMENTATION_BUILD_TIME)) {
+                buildTime = attrs.getValue(IMPLEMENTATION_BUILD_TIME);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            // Set the values read from manifest or the defaults
+            Number = number;
+            build_os = buildOS;
+            build_time = buildTime;
+            build_user = buildUser;
+        }
+    }
 
     public static String getVersionInfo() {
         StringBuffer sb = new StringBuffer();

--- a/tools/sigtest/src/test/java/com/sun/tdk/signaturetest/VersionIT.java
+++ b/tools/sigtest/src/test/java/com/sun/tdk/signaturetest/VersionIT.java
@@ -34,27 +34,23 @@ import static org.junit.Assert.assertNotNull;
 public class VersionIT {
     @Test
     public void testVersionDefaults() throws IOException {
-        // Load the filtered VersionIT.properties file for the maven build timestamp and project version
-        URL versionInfo = VersionIT.class.getResource("/VersionIT.properties");
+        // Load the generated git.properties file for the maven build timestamp and project version
+        URL versionInfo = VersionIT.class.getResource("/META-INF/git.properties");
         InputStream is = versionInfo.openStream();
-        assertNotNull("VersionIT.properties not found", is);
+        assertNotNull("/META-INF/git.properties not found", is);
         Properties props = new Properties();
         try (is){
             props.load(versionInfo.openStream());
         }
 
-        String number = props.getProperty("build.version");
+        String number = props.getProperty("git.build.version");
+        String buildTime = props.getProperty("git.commit.id.full");
+        String buildUser = props.getProperty("git.build.user.name");
         String buildOS = System.getProperty("os.name") + " " + System.getProperty("os.version");
-        String buildUser = System.getProperty("user.name");
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneId.of("GMT"));
-        String buildTime = props.getProperty("build.timestamp");
-        ZonedDateTime gmt = ZonedDateTime.parse(buildTime, formatter);
-        ZonedDateTime gmtTest = ZonedDateTime.parse(Version.build_time, formatter);
 
         assertEquals(number, Version.Number);
         assertEquals(buildOS, Version.build_os);
         assertEquals(buildUser, Version.build_user);
-        // Could be a problem on an overloaded CI server
-        assertEquals("Expect build timestamp diff < 5 secs", gmt.toEpochSecond(), gmtTest.toEpochSecond(), 5);
+        assertEquals(buildTime, Version.build_time);
     }
 }

--- a/tools/sigtest/src/test/java/com/sun/tdk/signaturetest/VersionIT.java
+++ b/tools/sigtest/src/test/java/com/sun/tdk/signaturetest/VersionIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.tdk.signaturetest;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Validate that the version information in the jar matches the expected maven build values.
+ */
+public class VersionIT {
+    @Test
+    public void testVersionDefaults() throws IOException {
+        // Load the filtered VersionIT.properties file for the maven build timestamp and project version
+        URL versionInfo = VersionIT.class.getResource("/VersionIT.properties");
+        InputStream is = versionInfo.openStream();
+        assertNotNull("VersionIT.properties not found", is);
+        Properties props = new Properties();
+        try (is){
+            props.load(versionInfo.openStream());
+        }
+
+        String number = props.getProperty("build.version");
+        String buildOS = System.getProperty("os.name") + " " + System.getProperty("os.version");
+        String buildUser = System.getProperty("user.name");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneId.of("GMT"));
+        String buildTime = props.getProperty("build.timestamp");
+        ZonedDateTime gmt = ZonedDateTime.parse(buildTime, formatter);
+        ZonedDateTime gmtTest = ZonedDateTime.parse(Version.build_time, formatter);
+
+        assertEquals(number, Version.Number);
+        assertEquals(buildOS, Version.build_os);
+        assertEquals(buildUser, Version.build_user);
+        // Could be a problem on an overloaded CI server
+        assertEquals("Expect build timestamp diff < 5 secs", gmt.toEpochSecond(), gmtTest.toEpochSecond(), 5);
+    }
+}

--- a/tools/sigtest/src/test/resources/VersionIT.properties
+++ b/tools/sigtest/src/test/resources/VersionIT.properties
@@ -1,0 +1,3 @@
+#
+build.version=${project.version}
+build.timestamp=${maven.build.timestamp}

--- a/tools/sigtest/src/test/resources/VersionIT.properties
+++ b/tools/sigtest/src/test/resources/VersionIT.properties
@@ -1,3 +1,0 @@
-#
-build.version=${project.version}
-build.timestamp=${maven.build.timestamp}


### PR DESCRIPTION
- Update the com.sun.tdk.signaturetest.Version class to get version info from the artifact jar manifest.
- Remove the obsolete release profile used in jboss fork
- Fixes #33