### PR TITLE
issue:72 tck-rewrite-ant (TestPackageInfoBuilder) needs additional mappings for Mappings from EE11 to EE10 package prefixes for Persistence

### DIFF
--- a/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/api/TestPackageInfoBuilder.java
+++ b/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/api/TestPackageInfoBuilder.java
@@ -59,6 +59,10 @@ public class TestPackageInfoBuilder {
     };
     // Mappings from EE11 to EE10 package prefixes
     private static final String[] EE11_PKG_PREFIXES = {
+        "ee.jakarta.tck.persistence.jpa.ee.packaging.jar", "com.sun.ts.tests.jpa.ee.packaging.jar",
+        "ee.jakarta.tck.persistence.entitytest.persist.oneXmanyFetchEager","com.sun.ts.tests.jpa.core.entitytest.persist.oneXmanyFetchEager",
+        "ee.jakarta.tck.persistence.core.persistenceUnitUtil","com.sun.ts.tests.jpa.core.persistenceUtilUtil", // map for package typo fixed in EE 11
+        "ee.jakarta.tck.persistence.core", "com.sun.ts.tests.jpa.core",
         "ee.jakarta.tck.persistence", "com.sun.ts.tests.jpa"
     };
     // Path to EE10 TCK dist


### PR DESCRIPTION
Address https://github.com/eclipse-ee4j/jakartaee-tck-tools/issues/72