### PR TITLE
issue 78, Generate JsfClientEjblitejsfTest.java for input JsfClient.java instead of ClientEjblitejsfTest.java which conflicts with input Client.java

### DIFF
--- a/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/api/TestPackageInfoBuilder.java
+++ b/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/api/TestPackageInfoBuilder.java
@@ -204,7 +204,7 @@ public class TestPackageInfoBuilder {
                 DeploymentMethodInfo methodInfo = parseVehiclePackage(pkgTargetWrapper, clazz, vehicleType);
                 // The class name of the generated clazz subclass
                 String vehicleName = capitalizeFirst(vehicleType.name());
-                String genTestClassName = "Client"+vehicleName+"Test";
+                String genTestClassName = testClassSimpleName+vehicleName+"Test";
                 TestClientInfo testClientInfo = new TestClientInfo(genTestClassName, clazz, testMethods);
                 testClientInfo.setVehicle(vehicleType);
                 testClientInfo.setTestDeployment(methodInfo);


### PR DESCRIPTION
Address https://github.com/eclipse-ee4j/jakartaee-tck-tools/issues/78

With this change, I no longer get `WARNING: TODO: src/main/java/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/webrw/ClientEjbliteservletTest.java was already previously generated which means we aren't handling something correctly.` warnings when transforming the ejb30 tests.