### PR TITLE
fix nested class name issue 89

### DIFF
--- a/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/Utils.java
+++ b/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/Utils.java
@@ -256,7 +256,11 @@ public class Utils {
                         if(Character.isDigit(dotClass.charAt(dollar+1))) {
                             anonymousClasses.add(dotClass);
                             continue;
-                    }
+                        } else {
+                            // skip nested class name com/sun/ts/lib/harness/EETest$Fault.class
+                            // clazz = dotClass.substring(0,dotClass.indexOf('$')) + ".class";
+                            continue;
+                        }
                     }
                     classes.add(clazz);
                 }

--- a/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/Utils.java
+++ b/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/Utils.java
@@ -256,9 +256,7 @@ public class Utils {
                         if(Character.isDigit(dotClass.charAt(dollar+1))) {
                             anonymousClasses.add(dotClass);
                             continue;
-                        } else {
-                            clazz = dotClass.replace('$', '.');
-                        }
+                    }
                     }
                     classes.add(clazz);
                 }

--- a/tools/tck-rewrite/pom.xml
+++ b/tools/tck-rewrite/pom.xml
@@ -93,6 +93,7 @@
             <groupId>jakarta.tck</groupId>
             <artifactId>jar2shrinkwrap</artifactId>
             <version>${version.tcktools}</version>
+            <scope>provided</scope> 
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>


### PR DESCRIPTION
https://github.com/eclipse-ee4j/jakartaee-tck-tools/issues/89 to preserve the added nested class like we see done in the EE 10 ant build.xml:
>
> <property name="appclient.jar.classes"
              value="
com/sun/ts/lib/harness/EETest$Fault.class,
com/sun/ts/lib/harness/EETest$SetupException.class,
com/sun/ts/lib/harness/EETest.class,

