### PR TITLE
Generalize the ee11 testClass mapping

### DIFF
--- a/tools/tck-rewrite-ant/src/test/java/tck/conversion/ant/api/DefaultMappingsTest.java
+++ b/tools/tck-rewrite-ant/src/test/java/tck/conversion/ant/api/DefaultMappingsTest.java
@@ -18,15 +18,37 @@ public class DefaultMappingsTest {
     @EnabledIfSystemProperty(named = "ts.home", matches = ".*")
     @Test
     public void testClassNMappings() {
-        DefaultEEMapping mappings = (DefaultEEMapping) DefaultEEMapping.getInstance();
+        DefaultEEMapping mappings = DefaultEEMapping.getInstance();
         Class<?> baseTestClass = ee.jakarta.tck.persistence.core.entityManager.Client2.class;
         String ee10Name = mappings.addTestClassMapping(baseTestClass, tsHome);
-        Assertions.assertEquals("com.sun.ts.tests.jpa.core.entityManager.Client.class", ee10Name);
+        Assertions.assertEquals("com.sun.ts.tests.jpa.core.entityManager.Client", ee10Name);
 
         // TsFileSet(String dir, String prefix, List<String> includes) {
         Path testDir = tsHome.resolve("classes");
         TsFileSet fileSet = new TsFileSet(testDir.toString(), "", List.of("com/sun/ts/tests/jpa/core/entityManager/Client.class"));
         String classes = Utils.getClassFilesString(mappings, List.of(fileSet), new ArrayList<>());
         Assertions.assertEquals(baseTestClass.getName()+".class", classes);
+    }
+
+    /**
+     * https://github.com/eclipse-ee4j/jakartaee-tck-tools/issues/97
+     */
+    @Test
+    public void testClassNNestedMappings() {
+        DefaultEEMapping mappings = DefaultEEMapping.getInstance();
+        Class<?> baseTestClass = ee.jakarta.tck.persistence.core.criteriaapi.CriteriaQuery.Client1.class;
+        String ee10Name = mappings.addTestClassMapping(baseTestClass, tsHome);
+        Assertions.assertEquals("com.sun.ts.tests.jpa.core.criteriaapi.CriteriaQuery.Client", ee10Name);
+
+        // TsFileSet(String dir, String prefix, List<String> includes) {
+        Path testDir = tsHome.resolve("classes");
+        ArrayList<String> includes = new ArrayList<>();
+        includes.add("com/sun/ts/tests/jpa/core/criteriaapi/CriteriaQuery/Client.class");
+        includes.add("com/sun/ts/tests/jpa/core/criteriaapi/CriteriaQuery/Client$ExpectedResult.class");
+        TsFileSet fileSet = new TsFileSet(testDir.toString(), "", includes);
+        String classes = Utils.getClassFilesString(mappings, List.of(fileSet), new ArrayList<>());
+        System.out.println(classes);
+        Assertions.assertTrue(classes.contains(baseTestClass.getName()+".class"));
+        Assertions.assertTrue(classes.contains(baseTestClass.getName()+".ExpectedResult.class"));
     }
 }


### PR DESCRIPTION
Generalize the ee11 testClass mapping so that the ClientN class and any inner classes are mapped
Fixes #97 