### PR TITLE
Correct arquillian dependency to 1.9.1.Final

### DIFF
--- a/tools/tck-rewrite-ant/pom.xml
+++ b/tools/tck-rewrite-ant/pom.xml
@@ -18,7 +18,8 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.arquillian>1.7.0.Final</version.arquillian>
+        <version.arquillian>1.9.1.Final</version.arquillian>
+        <version.shrinkwrap>1.2.6</version.shrinkwrap>
         <version.http-commons>3.1</version.http-commons>
         <version.openrewrite>8.7.2</version.openrewrite>
         <version.servlet-api>6.0.0</version.servlet-api>
@@ -34,6 +35,11 @@
                 <version>${version.arquillian}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-api</artifactId>
+                <version>${version.shrinkwrap}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -75,10 +81,6 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>

--- a/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/TsTaskListener.java
+++ b/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/TsTaskListener.java
@@ -247,9 +247,13 @@ public class TsTaskListener implements BuildListener {
                 String dir = fs.getDir().getAbsolutePath();
                 String[] includes = fs.getDirectoryScanner().getIncludedFiles();
                 if(includes.length > 0) {
-                    TsFileSet copyFS = new TsFileSet(dir, null, new ArrayList<>(List.of(includes)));
                     TsTaskInfo lastTsTask = tsTaskStack.peek();
-                    lastTsTask.addCopyFS(copyFS);
+                    TsFileSet copyFS = new TsFileSet(dir, null, new ArrayList<>(List.of(includes)));
+                    if(lastTsTask == null) {
+                        log.warning("No ts.* task for copy task for: "+copyFS);
+                    } else {
+                        lastTsTask.addCopyFS(copyFS);
+                    }
                 }
             }
         } else {

--- a/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/api/TestPackageInfoBuilder.java
+++ b/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/api/TestPackageInfoBuilder.java
@@ -186,6 +186,10 @@ public class TestPackageInfoBuilder {
             PackageTarget pkgTargetWrapper = new PackageTarget(new ProjectWrapper(project), antPackageTarget);
 
             DeploymentMethodInfo methodInfo = parseNonVehiclePackage(pkgTargetWrapper, clazz);
+            // Add a tag for the protocol so one can filter tests by protocol
+            String protocol = methodInfo.getDebugInfo().getProtocol();
+            ArrayList<String> extraTags = new ArrayList<>(tags);
+            extraTags.add("tck-"+protocol);
             // The class name of the generated clazz subclass
             String genTestClassName = "ClientTest";
             if(testClassSimpleName.equals("ClientTest")) {
@@ -195,7 +199,7 @@ public class TestPackageInfoBuilder {
             testClientInfo.setVehicle(VehicleType.none);
             testClientInfo.setTestDeployment(methodInfo);
             testClientInfo.setCommonDeployment(commonDeployment);
-            testClientInfo.setTags(tags);
+            testClientInfo.setTags(extraTags);
             testClientInfos.add(testClientInfo);
         } else {
 
@@ -211,6 +215,10 @@ public class TestPackageInfoBuilder {
                 Target antPackageTarget = project.getTargets().get("package");
                 PackageTarget pkgTargetWrapper = new PackageTarget(new ProjectWrapper(project), antPackageTarget);
                 DeploymentMethodInfo methodInfo = parseVehiclePackage(pkgTargetWrapper, clazz, vehicleType);
+                // Add a tag for the protocol so one can filter tests by protocol
+                String protocol = methodInfo.getDebugInfo().getProtocol();
+                ArrayList<String> vehicleTags = new ArrayList<>(tags);
+                vehicleTags.add("tck-"+protocol);
                 // The class name of the generated clazz subclass
                 String vehicleName = capitalizeFirst(vehicleType.name());
                 String genTestClassName = testClassSimpleName+vehicleName+"Test";
@@ -218,7 +226,7 @@ public class TestPackageInfoBuilder {
                 testClientInfo.setVehicle(vehicleType);
                 testClientInfo.setTestDeployment(methodInfo);
                 testClientInfo.setCommonDeployment(commonDeployment);
-                testClientInfo.setTags(tags);
+                testClientInfo.setTags(vehicleTags);
                 testClientInfos.add(testClientInfo);
             }
         }

--- a/tools/tck-rewrite-ant/src/test/java/tck/conversion/ant/api/DeploymentMethodTest.java
+++ b/tools/tck-rewrite-ant/src/test/java/tck/conversion/ant/api/DeploymentMethodTest.java
@@ -361,6 +361,19 @@ public class DeploymentMethodTest {
         System.out.println(packageInfo);
         System.out.println(packageInfo.getTestClientFiles());
     }
+    @Test
+    public void testejb32_lite_timer_basic_xa() throws IOException {
+        TestPackageInfoBuilder builder = new TestPackageInfoBuilder(tsHome);
+        List<TestMethodInfo> testMethods = Arrays.asList(
+                new TestMethodInfo("persistCoffeeCreateTimerRollbackStateless", ""),
+                new TestMethodInfo("persistCoffeeCreateTimerRollbackSingleton", "")
+        );
+        Class<?> baseTestClass = com.sun.ts.tests.ejb32.lite.timer.basic.xa.Client.class;
+        TestPackageInfo packageInfo = builder.buildTestPackgeInfoEx(baseTestClass, testMethods, DefaultEEMapping.getInstance());
+        System.out.println(packageInfo);
+        System.out.println(packageInfo.getTestClientFiles());
+    }
+
 
     @Test
     public void testEjb32_relaxedclientview_singleton() throws IOException {

--- a/tools/tck-rewrite/pom.xml
+++ b/tools/tck-rewrite/pom.xml
@@ -19,12 +19,12 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.arquillian>1.7.0.Final</version.arquillian>
+        <version.arquillian>1.9.1.Final</version.arquillian>
+        <version.shrinkwrap>1.2.6</version.shrinkwrap>
         <version.http-commons>3.1</version.http-commons>
         <version.openrewrite>8.7.2</version.openrewrite>
         <version.ignoreopenrewrite>8.23.3</version.ignoreopenrewrite>
         <version.servlet-api>6.0.0</version.servlet-api>
-        <version.tcktools>1.0.0-SNAPSHOT</version.tcktools>
         <version.platform.tck>11.0.0-SNAPSHOT</version.platform.tck>
     </properties>
 
@@ -78,10 +78,7 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>${version.shrinkwrap}</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>

--- a/tools/tck-rewrite/src/main/java/tck/jakarta/platform/rewrite/GenerateNewTestClassRecipe.java
+++ b/tools/tck-rewrite/src/main/java/tck/jakarta/platform/rewrite/GenerateNewTestClassRecipe.java
@@ -52,11 +52,13 @@ public class GenerateNewTestClassRecipe extends Recipe implements Serializable {
 
     static final long serialVersionUID = 427023419L;
     private static final String fullyQualifiedClassName = GenerateNewTestClassRecipe.class.getCanonicalName();
+    // EE10 tck home
     private static final Path tsHome = Paths.get(System.getProperty("ts.home"));
-
+    // EE11 tck module src root, usually src/main/java
     private static final Path srcDir = Paths.get(System.getProperty("tcksourcepath"));
-
+    // Optional property to restrict to a specific test package
     private static final String tckpackage = System.getProperty("tckpackage");
+    private static boolean overwriteExistingTests = Boolean.valueOf(System.getProperty("overwriteExistingTests", "false"));
 
     static {
         if (log.isLoggable(Level.FINEST)) {
@@ -193,7 +195,7 @@ public class GenerateNewTestClassRecipe extends Recipe implements Serializable {
                         Files.createDirectories(testPkgDir);
                         // The test client .java file
                         Path testClientJavaFile = testPkgDir.resolve(testClient.getName() + ".java");
-                        if (testClientJavaFile.toFile().exists()) {
+                        if (!overwriteExistingTests && testClientJavaFile.toFile().exists()) {
                             log.warning("TODO: " + testClientJavaFile + " was already previously generated which means we aren't handling something correctly.");
                             Thread.dumpStack();
                             continue;


### PR DESCRIPTION
Add a overwriteExistingTests flag to GenerateNewTestClassRecipe Correct a failure when a copy inside the package target was seen