### PR TITLE
issue 105, Truncate output files when using tck-rewrite overwriteExistingTests

### DIFF
--- a/tools/tck-rewrite/src/main/java/tck/jakarta/platform/rewrite/GenerateNewTestClassRecipe.java
+++ b/tools/tck-rewrite/src/main/java/tck/jakarta/platform/rewrite/GenerateNewTestClassRecipe.java
@@ -201,7 +201,7 @@ public class GenerateNewTestClassRecipe extends Recipe implements Serializable {
                             continue;
                         }
                         // Write out the test client .java file content
-                        Files.writeString(testClientJavaFile, testClient.getContent(), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                        Files.writeString(testClientJavaFile, testClient.getContent(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
                         log.info("Generated " + testClientJavaFile + " for " + classDecl.getType().getFullyQualifiedName());
                     }
                 } else {


### PR DESCRIPTION
Interesting that order is important as this doesn't truncate the output file:
> Files.writeString(testClientJavaFile, testClient.getContent(), StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)

But this does truncate the output file:
> Files.writeString(testClientJavaFile, testClient.getContent(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)

^ makes sense that the parameters are processed in order