### PR TITLE
Many updates for outstanding issues

### DIFF
--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
@@ -38,6 +38,8 @@ public class AppClientProtocolConfiguration implements ProtocolConfiguration, Pr
     private String workDir;
     // EE10 type of ts.jte file location
     private String tsJteFile;
+    // EE10 type of tssql.stmt file location
+    private String tsSqlStmtFile;
     // harness.log.traceflag
     private boolean trace;
 
@@ -73,6 +75,15 @@ public class AppClientProtocolConfiguration implements ProtocolConfiguration, Pr
     }
     public void setTsJteFile(String tsJteFile) {
         this.tsJteFile = tsJteFile;
+    }
+
+    @Override
+    public String getTsSqlStmtFile() {
+        return tsSqlStmtFile;
+    }
+    @Override
+    public void setTsSqlStmtFile(String tsSqlStmtFile) {
+        this.tsSqlStmtFile = tsSqlStmtFile;
     }
 
     public String getClientEnvString() {

--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/ProtocolCommonConfig.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/ProtocolCommonConfig.java
@@ -9,4 +9,7 @@ public interface ProtocolCommonConfig {
 
     public String getTsJteFile();
     public void setTsJteFile(String tsJteFile);
+
+    public String getTsSqlStmtFile();
+    public void setTsSqlStmtFile(String tsJteFile);
 }

--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
@@ -22,8 +22,15 @@ public class TsTestPropsBuilder {
             "Driver",
             "authpassword",
             "authuser",
+            "binarySize",
+            "cofSize",
+            "cofTypeSize",
+            "db.dml.file",
             "db.supports.sequence",
             "db1",
+            "db2",
+            "DriverManager",
+            "ftable",
             "generateSQL",
             "harness.log.port",
             "harness.log.traceflag",
@@ -39,6 +46,7 @@ public class TsTestPropsBuilder {
             "jstl.db.password",
             "log.file.location",
             "logical.hostname.servlet",
+            "longvarbinarySize",
             "org.omg.CORBA.ORBClass",
             "password",
             "platform.mode",
@@ -53,6 +61,7 @@ public class TsTestPropsBuilder {
             // These two are probably not useful
             "porting.ts.deploy.class.1",
             "porting.ts.deploy.class.2",
+            "ptable",
             "rapassword1",
             "rapassword2",
             "rauser1",
@@ -61,6 +70,8 @@ public class TsTestPropsBuilder {
             "sigTestClasspath",
             "ts_home",
             "user",
+            "user1",
+            "varbinarySize",
             "webServerHost",
             "webServerPort",
             "whitebox-anno_no_md",
@@ -122,6 +133,7 @@ public class TsTestPropsBuilder {
 
         // We need the JavaTest ts.jte file for now
         Path tsJte = Paths.get(config.getTsJteFile());
+        Path tssqlStmt = Paths.get(config.getTsSqlStmtFile());
         // Create a test properties file
         Path testProps = Paths.get(config.getWorkDir(), "tstest.jte");
 
@@ -176,6 +188,7 @@ public class TsTestPropsBuilder {
         String[] args = {
                 // test props are needed by EETest.run
                 "-p", testProps.toFile().getAbsolutePath(),
+                "-ap", tssqlStmt.toFile().getAbsolutePath(),
                 "classname", testMethodExecutor.getMethod().getDeclaringClass().getName(),
                 "-t", tsTestMethodName,
                 "-vehicle", vehicle,

--- a/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestProtocolConfiguration.java
+++ b/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestProtocolConfiguration.java
@@ -10,6 +10,8 @@ public class JavaTestProtocolConfiguration implements ProtocolConfiguration, Pro
     private String workDir;
     // EE10 type of ts.jte file location
     private String tsJteFile;
+    // EE10 type of tssql.stmt file location
+    private String tsSqlStmtFile;
     // harness.log.traceflag
     private boolean trace;
     // Should the VehicleClient main be run in a separate JVM
@@ -29,6 +31,15 @@ public class JavaTestProtocolConfiguration implements ProtocolConfiguration, Pro
 
     public void setTsJteFile(String tsJteFile) {
         this.tsJteFile = tsJteFile;
+    }
+
+    @Override
+    public String getTsSqlStmtFile() {
+        return tsSqlStmtFile;
+    }
+    @Override
+    public void setTsSqlStmtFile(String tsSqlStmtFile) {
+        this.tsSqlStmtFile = tsSqlStmtFile;
     }
 
     public boolean isTrace() {

--- a/arquillian/protocol-lib/pom.xml
+++ b/arquillian/protocol-lib/pom.xml
@@ -73,8 +73,7 @@
                   <type>jar</type>
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                  <includes>**/*.class,**/*.xml</includes>
-                  <excludes>com/sun/ts/tests/common/vehicle/**</excludes>
+                  <includes>**/*.class</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/tools/tck-rewrite-ant/pom.xml
+++ b/tools/tck-rewrite-ant/pom.xml
@@ -134,6 +134,11 @@
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>
+            <artifactId>jdbc</artifactId>
+            <version>${version.platform.tck}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
             <artifactId>jms</artifactId>
             <version>${version.platform.tck}</version>
         </dependency>

--- a/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/api/DefaultEEMapping.java
+++ b/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/api/DefaultEEMapping.java
@@ -17,6 +17,7 @@ public class DefaultEEMapping implements EE11toEE10Mapping {
     };
     // Packages removed from EE11. Mostly ejb module classes that are not in the EE11 TCK
     private static final String[] EE11_PKG_EXCLUDES = {
+            "com.sun.ts.tests.common.vehicle.ejb.EJBVehicleHome",
             "com.sun.ts.tests.common.dao",
             "com.sun.ts.tests.assembly.util.refbean",
             "com.sun.ts.tests.ejb.ee.bb.entity",

--- a/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/api/TestPackageInfoBuilder.java
+++ b/tools/tck-rewrite-ant/src/main/java/tck/jakarta/platform/ant/api/TestPackageInfoBuilder.java
@@ -371,6 +371,15 @@ public class TestPackageInfoBuilder {
         Vehicles vehicleDef = pkgTargetWrapper.getVehiclesDef();
         ArrayList<String> foundDescriptors = new ArrayList<>();
         String extraClientClass = mapping.getMappedTestClass();
+        // Validate the extraClientClass exists in
+        if(extraClientClass != null) {
+            try {
+                deployment.testClass.getClassLoader().loadClass(extraClientClass);
+            } catch (ClassNotFoundException e) {
+                info("Failed to locate extra client class: %s\n", extraClientClass);
+                extraClientClass = null;
+            }
+        }
         // Client
         if(pkgTargetWrapper.hasClientJarDef()) {
             ClientJar clientJarDef = pkgTargetWrapper.getClientJarDef();

--- a/tools/tck-rewrite-ant/src/main/resources/TsClientJar.stg
+++ b/tools/tck-rewrite-ant/src/main/resources/TsClientJar.stg
@@ -25,7 +25,7 @@ genClientJar(client, testClass) ::= <<
     if(resURL != null) {
       #client.typedArchiveName#.addAsManifestResource(resURL, "application-client.xml");
     }
-    #client.typedArchiveName#.addAsManifestResource(new StringAsset("Main-Class: " + #testClass#.class.getName() + "\n"), "MANIFEST.MF");
+    #client.typedArchiveName#.addAsManifestResource(new StringAsset("Main-Class: #client.mainClass#\n"), "MANIFEST.MF");
     // Call the archive processor
     archiveProcessor.processClientArchive(#client.typedArchiveName#, #testClass#.class, resURL);
 >>

--- a/tools/tck-rewrite-ant/src/test/java/tck/conversion/ant/api/DeploymentMethodTest.java
+++ b/tools/tck-rewrite-ant/src/test/java/tck/conversion/ant/api/DeploymentMethodTest.java
@@ -708,4 +708,47 @@ public class DeploymentMethodTest {
         System.out.println("---- TestClientFiles ----");
         System.out.println(packageInfo.getTestClientFiles());
     }
+
+    @Test
+    public void test_jdbc_ee_batchUpdate() throws IOException {
+        TestPackageInfoBuilder builder = new TestPackageInfoBuilder(tsHome);
+        List<TestMethodInfo> testMethods = Arrays.asList(
+                new TestMethodInfo("sequenceGeneratorOnPropertyTest", "Exception")
+        );
+        Class<?> baseTestClass = com.sun.ts.tests.jdbc.ee.batchUpdate.batchUpdateClient.class;
+        TestPackageInfo packageInfo = builder.buildTestPackgeInfoEx(baseTestClass, testMethods, DefaultEEMapping.getInstance());
+        System.out.println(packageInfo);
+
+        DeploymentInfo deploymentInfo = packageInfo.getTestClients().get(0).getTestDeployment().getDebugInfo();
+        System.out.printf("Client: %s\n", deploymentInfo.getClientJar());
+        System.out.printf("Client.mainClass: %s\n", deploymentInfo.getClientJar().getMainClass());
+        System.out.printf("Client.classes: %s\n", deploymentInfo.getClientJar().getClassFilesString());
+        System.out.printf("Ejbs: %s\n", deploymentInfo.getEjbJars());
+        System.out.printf("Ejb1.classes: %s\n", deploymentInfo.getEjbJar().getClassFilesString());
+
+        System.out.println("---- TestClientFiles ----");
+        System.out.println(packageInfo.getTestClientFiles());
+    }
+
+
+    @Test
+    public void test_jpa_core_annotations_orderby() throws IOException {
+        TestPackageInfoBuilder builder = new TestPackageInfoBuilder(tsHome);
+        List<TestMethodInfo> testMethods = Arrays.asList(
+                new TestMethodInfo("test1", "Exception")
+        );
+        Class<?> baseTestClass = ee.jakarta.tck.persistence.core.annotations.orderby.Client1.class;
+        TestPackageInfo packageInfo = builder.buildTestPackgeInfoEx(baseTestClass, testMethods, DefaultEEMapping.getInstance());
+        System.out.println(packageInfo);
+
+        DeploymentInfo deploymentInfo = packageInfo.getTestClients().get(0).getTestDeployment().getDebugInfo();
+        System.out.printf("Client: %s\n", deploymentInfo.getClientJar());
+        System.out.printf("Client.mainClass: %s\n", deploymentInfo.getClientJar().getMainClass());
+        System.out.printf("Client.classes: %s\n", deploymentInfo.getClientJar().getClassFilesString());
+        System.out.printf("Ejbs: %s\n", deploymentInfo.getEjbJars());
+        System.out.printf("Ejb1.classes: %s\n", deploymentInfo.getEjbJar().getClassFilesString());
+
+        System.out.println("---- TestClientFiles ----");
+        System.out.println(packageInfo.getTestClientFiles());
+    }
 }


### PR DESCRIPTION
Remove the descriptors from the protocol.jar
Only use the extra Client.class if it exists in EE11
Add additional properties used by jdbc
Add a tssql.stmt config location to protocol common config
Use the ClientJar MainClass value in client jar manifest
Add com.sun.ts.tests.common.vehicle.ejb.EJBVehicleHome to excluded classes

Fixes #130
Fixes #128