### PR TITLE
tck-rewrite-ant: Persistence mapping-file (e.g. myMappingFile.xml) files are not added to deployments #140

### DIFF
--- a/tools/tck-rewrite-ant/src/main/resources/TsPar.stg
+++ b/tools/tck-rewrite-ant/src/main/resources/TsPar.stg
@@ -20,6 +20,19 @@ genPar(par, testClass) ::= <<
     if(parURL != null) {
       #par.typedArchiveName#.addAsManifestResource(parURL, "persistence.xml");
     }
+    // Add the Persistence mapping-file
+    URL mappingURL = #testClass#.class.getResource("myMappingFile.xml");
+    if(mappingURL != null) {
+      #par.typedArchiveName#.addAsResource(mappingURL, "myMappingFile.xml");
+    }
+    mappingURL = #testClass#.class.getResource("myMappingFile1.xml");
+    if(mappingURL != null) {
+      #par.typedArchiveName#.addAsResource(mappingURL, "myMappingFile1.xml");
+    }
+    mappingURL = #testClass#.class.getResource("myMappingFile2.xml");
+    if(mappingURL != null) {
+      #par.typedArchiveName#.addAsResource(mappingURL, "myMappingFile2.xml");
+    }
     // Call the archive processor
     archiveProcessor.processParArchive(#par.typedArchiveName#, #testClass#.class, parURL);
     // The orm.xml file


### PR DESCRIPTION
https://github.com/eclipse-ee4j/jakartaee-tck-tools/issues/140

The following additional mapping handling is added for all persistence.xml specifically if we detect a myMappingFile.xml file:

```
 if(parURL != null) {
   jpa_core_EntityGraph.addAsResource(parURL, "persistence.xml");
 }
// Add the Persistence mapping-file
URL mappingURL = Client.class.getResource("myMappingFile.xml");
if(mappingURL != null) {
  jpa_core_EntityGraph.addAsResource(mappingURL, "myMappingFile.xml");
}
mappingURL = Client.class.getResource("myMappingFile1.xml");
if(mappingURL != null) {
  jpa_core_EntityGraph.addAsResource(mappingURL, "myMappingFile1.xml");
}
mappingURL = Client.class.getResource("myMappingFile2.xml");
if(mappingURL != null) {
  jpa_core_EntityGraph.addAsResource(mappingURL, "myMappingFile2.xml");
}

```