### PR TITLE
Arquillian should check for system property if ts.home is not set in ts.jte file issues/145

### DIFF
--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
@@ -176,6 +176,9 @@ public class TsTestPropsBuilder {
                 if(propValue.startsWith("${") && propValue.endsWith("}")) {
                     String refName = propValue.substring(2, propValue.length() - 1);
                     propValue = tsJteProps.getProperty(refName);
+                    if(propValue == null && refName != null) {
+                        propName = System.getProperty(refName);
+                    }
                     log.info(String.format("Setting property %s -> %s to %s", propName, refName, propValue));
                     if(propValue == null) {
                         continue;


### PR DESCRIPTION
https://github.com/eclipse-ee4j/jakartaee-tck-tools/issues/145

For properties like ts.home, if they are not found in the ts.jte, look in system properties.