### PR TITLE
Add tsjte property variable.mapper used for EL tests

### DIFF
--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
@@ -80,6 +80,7 @@ public class TsTestPropsBuilder {
             "user",
             "user1",
             "varbinarySize",
+            "variable.mapper",
             "vehicle_ear_name",
             "webServerHost",
             "webServerPort",


### PR DESCRIPTION
The EL tests fail with missing property variable.mapper that is read from ts.jte file.