### PR TITLE
Arquillian correction/improvement for check for system property if ts.home is not set in ts.jte file issues/145

### DIFF
--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
@@ -187,12 +187,16 @@ public class TsTestPropsBuilder {
                     String refName = propValue.substring(2, propValue.length() - 1);
                     propValue = tsJteProps.getProperty(refName);
                     if(propValue == null && refName != null) {
-                        propName = System.getProperty(refName);
+                        propValue = System.getProperty(refName);
                     }
                     log.info(String.format("Setting property %s -> %s to %s", propName, refName, propValue));
-                    if(propValue == null) {
-                        continue;
-                    }
+                }
+                if(propValue == null) {
+                    propValue = System.getProperty(propName);
+                }
+
+                if(propValue == null) {
+                    continue;
                 }
                 props.setProperty(propName, propValue);
             }


### PR DESCRIPTION
Correction for reopened https://github.com/eclipse-ee4j/jakartaee-tck-tools/issues/145 in response to feedback on https://github.com/eclipse-ee4j/jakartaee-tck-tools/pull/146 (e.g. actually sets the property value variable).

Also ensures we don't try to put a null property which gets a NPE and adds an additional system property check.