### PR TITLE
[154] Add back the ability to pass -IgnoreJDKClass with an argument. …

### DIFF
--- a/tools/sigtest/README.md
+++ b/tools/sigtest/README.md
@@ -146,11 +146,14 @@ with the action option set to `strictcheck` the plugin will detect any API chang
 
 There are some cases where avoiding the verification of certain JDK classes entirely or their signatures can improve the ability to verify your API on different JDK versions.
 The `-IgnoreJDKClasses` option will ignore (all) JDK java.* and javax.* classes during signature verification checking which helps avoid failures caused by 
-JDK specific signature changes introduced by a later JDK version. As an example, a Signature file with @java.lang.Deprecated annotations from JDK8 may be seeing verification failures on JDK9+ 
-due to `default` fields being added to @Deprecated.  With `-IgnoreJDKClasses specified, verification of the @Deprecated will only check that the tested class member has the 
-@Deprecated class but no verification of the @Deprecated signature will be performed. 
+JDK specific signature changes introduced by a later JDK version. As an example, a Signature file with `@java.lang.Deprecated` annotations from JDK8 may be seeing verification failures on JDK9+ 
+due to `default` fields being added to `@Deprecated`.  With `-IgnoreJDKClasses` specified, verification of the `@Deprecated` will only check that the tested class member has the 
+`@Deprecated` class but no verification of the `@Deprecated` signature will be performed. 
 
-Note that the `-IgnoreJDKClass` option can still be specified only if no JDK Class name is included after the `-IgnoreJDKClass`.  You will get a failure if you try to use `-IgnoreJDKClass JDKClassName`.
+In 2.4, the `-IgnoreJDKClass` was re-introduced to the previous behavior, with one exception. If you pass `-IgnoreJDKClass` with no argument, it's the same as passing `-IgnoreJDKClasses`.
+However, you can now pass class name arguments to the `-IgnoreJDKClass` option like you could in previous version.
+
+These options should likely be used sparingly. Using the `-Release` option the minimum target version of the API is the suggested way to handle forward compatibility for signature tests.
 
 ### Specify JDK classes to ignore in Maven plugin
 Specify the `-IgnoreJDKClasses` option as shown below:

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/Setup.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/Setup.java
@@ -230,7 +230,7 @@ public class Setup extends SigTest {
 
         parser.addOption(EXCLUDE_JDK_CLASS_OPTION, OptionInfo.optionalFlag(), optionsDecoder);
 
-        parser.addOption(LEGACY_EXCLUDE_JDK_CLASS_OPTION, OptionInfo.optionalFlag(), optionsDecoder);
+        parser.addOption(LEGACY_EXCLUDE_JDK_CLASS_OPTION, OptionInfo.optionVariableParams(0, OptionInfo.UNLIMITED), optionsDecoder);
 
         try {
             parser.processArgs(args);

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/SetupAndTest.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/SetupAndTest.java
@@ -87,7 +87,7 @@ public class SetupAndTest extends Result {
         parser.addOption(SigTest.PACKAGE_OPTION, OptionInfo.optionVariableParams(1, OptionInfo.UNLIMITED), optionsDecoder);
         parser.addOption(SigTest.FILENAME_OPTION, OptionInfo.option(1), optionsDecoder);
         parser.addOption(SigTest.EXCLUDE_JDK_CLASS_OPTION, OptionInfo.optionalFlag(), optionsDecoder);
-        parser.addOption(LEGACY_EXCLUDE_JDK_CLASS_OPTION, OptionInfo.optionalFlag(), optionsDecoder);
+        parser.addOption(LEGACY_EXCLUDE_JDK_CLASS_OPTION, OptionInfo.optionVariableParams(0, OptionInfo.UNLIMITED), optionsDecoder);
         parser.addOption(SigTest.WITHOUTSUBPACKAGES_OPTION, OptionInfo.optionVariableParams(1, OptionInfo.UNLIMITED), optionsDecoder);
         parser.addOption(SigTest.EXCLUDE_OPTION, OptionInfo.optionVariableParams(1, OptionInfo.UNLIMITED), optionsDecoder);
         parser.addOption(SigTest.APIVERSION_OPTION, OptionInfo.option(1), optionsDecoder);
@@ -180,7 +180,11 @@ public class SetupAndTest extends Result {
         } else if (optionName.equalsIgnoreCase(SigTest.EXCLUDE_JDK_CLASS_OPTION)) {
             addFlag(testOptions, SigTest.EXCLUDE_JDK_CLASS_OPTION);
         } else if (optionName.equalsIgnoreCase(LEGACY_EXCLUDE_JDK_CLASS_OPTION)) {
-            addFlag(testOptions, SigTest.EXCLUDE_JDK_CLASS_OPTION);
+            if (args == null || args.length == 0) {
+                addFlag(testOptions, SigTest.EXCLUDE_JDK_CLASS_OPTION);
+            } else {
+                addOption(testOptions, SigTest.LEGACY_EXCLUDE_JDK_CLASS_OPTION, args[0]);
+            }
         } else if (optionName.equalsIgnoreCase(SigTest.FILENAME_OPTION) ||
                 optionName.equalsIgnoreCase(SigTest.PACKAGE_OPTION) ||
                 optionName.equalsIgnoreCase(SigTest.WITHOUTSUBPACKAGES_OPTION) ||

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/ClassCorrector.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/ClassCorrector.java
@@ -56,6 +56,7 @@ public class ClassCorrector implements Transformer {
 
     protected ClassHierarchy classHierarchy = null;
     private Log log;
+    private final JDKExclude jdkExclude;
 
     /**
      * Selftracing can be turned on by setting FINER level
@@ -76,13 +77,25 @@ public class ClassCorrector implements Transformer {
 
 
     private static I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(ClassCorrector.class);
-    
-    public ClassCorrector(Log log) {
+
+    public ClassCorrector(Log log, JDKExclude jdkExclude) {
+        this.jdkExclude = jdkExclude != null ? jdkExclude :
+                new JDKExclude() {
+                    @Override
+                    public boolean isJdkClass(String name) {
+                        return false;
+                    }
+                };
         this.log = log;
         // not configured externally
         if(logger.getLevel() == null) {
             logger.setLevel(Level.OFF);
         }
+
+    }
+
+    public ClassCorrector(Log log) {
+        this(log, null);
     }
 
 
@@ -180,7 +193,7 @@ public class ClassCorrector implements Transformer {
                 } else
                     exceptionName = throwables.substring(startPos);
 
-                if (!JDKExclude.isJdkClass(exceptionName) && isInvisibleClass(exceptionName)) {
+                if (!jdkExclude.isJdkClass(exceptionName) && isInvisibleClass(exceptionName)) {
                     List supers = classHierarchy.getSuperClasses(exceptionName);
                     exceptionName = findVisibleReplacement(exceptionName, supers, "java.lang.Throwable", true);
                     mustCorrect = true;
@@ -700,7 +713,7 @@ public class ClassCorrector implements Transformer {
 
         if (fqname.startsWith("?"))
             return false;
-        if (JDKExclude.isJdkClass(fqname))
+        if (jdkExclude.isJdkClass(fqname))
             return false;
         String pname = ClassCorrector.stripArrays(ClassCorrector.stripGenerics(fqname));
 

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/JDKExclude.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/JDKExclude.java
@@ -32,23 +32,22 @@ package com.sun.tdk.signaturetest.core;
  *
  * @author Scott Marlow
  */
-public class JDKExclude {
+public interface JDKExclude {
 
-    private static PackageGroup excludedJdkClasses = new PackageGroup(true);
-
-    public static void enable() {
+    /**
+     * A default filter which excludes classes that start with {@code java} and {@code javax}.
+     */
+    JDKExclude JDK_CLASSES = (name) -> {
+        final PackageGroup excludedJdkClasses = new PackageGroup(true);
         excludedJdkClasses.addPackages(new String[] {"java", "javax" });
-    }
+        return excludedJdkClasses.checkName(name);
+    };
 
     /**
      * Check for JDK classes that should be excluded from signature testing.
      * @param name is class name (with typical dot separators) to check.
      * @return true if the class should be excluded from signature testing.
      */
-    public static boolean isJdkClass(String name) {
-        return name != null &&
-                excludedJdkClasses.checkName(name);
-
-    }
+    boolean isJdkClass(String name);
 
 }

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/MemberCollectionBuilder.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/MemberCollectionBuilder.java
@@ -76,6 +76,16 @@ public class MemberCollectionBuilder {
      */
     static Logger logger = Logger.getLogger(MemberCollectionBuilder.class.getName());
 
+    public MemberCollectionBuilder(Log log, JDKExclude jdkExclude) {
+        this.cc = jdkExclude == null ? new ClassCorrector(log) : new ClassCorrector(log, jdkExclude);
+        this.log = log;
+
+        // not configured externally
+        if (logger.getLevel() == null) {
+            logger.setLevel(Level.OFF);
+        }
+    }
+
     public MemberCollectionBuilder(Log log) {
         this.cc = new ClassCorrector(log);
         this.log = log;

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/ThrowsNormalizer.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/core/ThrowsNormalizer.java
@@ -46,6 +46,9 @@ public class ThrowsNormalizer {
     public ThrowsNormalizer() {
         
     }
+    public ThrowsNormalizer(JDKExclude jdkExclude) {
+        this.jdkExclude = jdkExclude;
+    }
 
     public void normThrows(ClassDescription c, boolean removeJLE, boolean onlyRemoveJavaSEThrows) throws ClassNotFoundException {
 
@@ -97,7 +100,7 @@ public class ThrowsNormalizer {
                 if (s == null)
                     continue;
 
-                if (JDKExclude.isJdkClass(s) ) {
+                if (jdkExclude.isJdkClass(s) ) {
                     xthrows.set(i, null);
                     superfluousExceptionCount++;
                 }
@@ -153,5 +156,10 @@ public class ThrowsNormalizer {
     
     private List/*String*/ xthrows = new ArrayList();
     private StringBuffer sb = new StringBuffer();
-
+    private JDKExclude jdkExclude = new JDKExclude() {
+        @Override
+        public boolean isJdkClass(String name) {
+            return false;
+        }
+    };
 }

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/Sigtest.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/Sigtest.java
@@ -48,8 +48,6 @@ public final class Sigtest extends Task {
     String failureProperty;
     String release;
 
-    Boolean jdkExcludeEnabled = Boolean.FALSE;
-
     public void setFileName(File f) {
         fileName = f;
     }
@@ -178,7 +176,12 @@ public final class Sigtest extends Task {
 
             @Override
             protected boolean isJDKExcludeEnabled() {
-                return jdkExcludeEnabled.booleanValue();
+                return false;
+            }
+
+            @Override
+            protected String[] getIgnoreJDKClassEntries() {
+                return null;
             }
         };
         int returnCode;

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCheck.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCheck.java
@@ -26,6 +26,7 @@ package org.netbeans.apitest;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -99,14 +100,14 @@ public final class SigtestCheck extends AbstractMojo {
     @Parameter(defaultValue = "true", property = "sigtest.fail")
     private boolean failOnError;
     @Parameter(defaultValue = "false", property = "IgnoreJDKClasses")
-    private boolean ignoreJDKClasses;
-    @Parameter(defaultValue = "false", property = "IgnoreJDKClass")
-    private boolean legacyIgnoreJDKClasses; 
+    private String[] ignoreJDKClasses;
+    @Parameter(defaultValue = "false", property = "IgnoreAllJDKClasses")
+    private boolean ignoreAllJDKClasses;
 
     public SigtestCheck() {
     }
 
-    SigtestCheck(MavenProject prj, File classes, File sigfile, String action, String packages, File report, boolean failOnError, boolean ignoreJDKClasses) {
+    SigtestCheck(MavenProject prj, File classes, File sigfile, String action, String packages, File report, boolean failOnError, final String[] ignoreJDKClasses, boolean ignoreAllJDKClasses) {
         this.prj = prj;
         this.classes = classes;
         this.sigfile = sigfile;
@@ -114,7 +115,8 @@ public final class SigtestCheck extends AbstractMojo {
         this.packages = packages;
         this.report = report;
         this.failOnError = failOnError;
-        this.ignoreJDKClasses = ignoreJDKClasses;
+        this.ignoreJDKClasses = Arrays.copyOf(ignoreJDKClasses, ignoreJDKClasses.length);
+        this.ignoreAllJDKClasses = ignoreAllJDKClasses;
     }
 
 
@@ -193,7 +195,12 @@ public final class SigtestCheck extends AbstractMojo {
 
             @Override
             protected boolean isJDKExcludeEnabled() {
-                return ignoreJDKClasses || legacyIgnoreJDKClasses;
+                return ignoreAllJDKClasses;
+            }
+
+            @Override
+            protected String[] getIgnoreJDKClassEntries() {
+                return ignoreJDKClasses;
             }
         };
         try {

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCompare.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCompare.java
@@ -75,9 +75,9 @@ public final class SigtestCompare extends AbstractMojo {
     @Parameter(defaultValue = "true", property = "sigtest.fail")
     private boolean failOnError;
     @Parameter(defaultValue = "false", property = "IgnoreJDKClasses")
-    private boolean ignoreJDKClasses;
-    @Parameter(defaultValue = "false", property = "IgnoreJDKClass")
-    private boolean legacyIgnoreJDKClasses;
+    private String[] ignoreJDKClasses;
+    @Parameter(defaultValue = "false", property = "IgnoreAllJDKClasses")
+    private boolean ignoreAllJDKClasses;
 
 
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -99,10 +99,10 @@ public final class SigtestCompare extends AbstractMojo {
             throw new MojoExecutionException("Cannot resolve " + artifact, ex);
         }
 
-        SigtestGenerate generate = new SigtestGenerate(prj, artifact.getFile(), sigfile, packages, releaseVersion, release, ignoreJDKClasses || legacyIgnoreJDKClasses);
+        SigtestGenerate generate = new SigtestGenerate(prj, artifact.getFile(), sigfile, packages, releaseVersion, release, ignoreJDKClasses, ignoreAllJDKClasses);
         generate.execute();
 
-        SigtestCheck check = new SigtestCheck(prj, classes, sigfile, action, packages, report, failOnError, ignoreJDKClasses || legacyIgnoreJDKClasses);
+        SigtestCheck check = new SigtestCheck(prj, classes, sigfile, action, packages, report, failOnError, ignoreJDKClasses, ignoreAllJDKClasses);
         check.execute();
     }
 }

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestGenerate.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestGenerate.java
@@ -26,6 +26,8 @@ package org.netbeans.apitest;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -84,21 +86,29 @@ public final class SigtestGenerate extends AbstractMojo {
     @Parameter(defaultValue = "true")
     private boolean attach;
     
-    private String version;
+    /**
+     * ignore JDK classes entries
+     */
+    @Parameter
+    private String[] ignoreJDKClasses;
 
-    private boolean ignoreJDKClasses;
+    @Parameter(defaultValue = "false")
+    private boolean ignoreAllJdkClasses;
+
+    private String version;
 
     public SigtestGenerate() {
     }
 
-    SigtestGenerate(MavenProject prj, File classes, File sigfile, String packages, String version, String release, boolean ignoreJDKClasses) {
+    SigtestGenerate(MavenProject prj, File classes, File sigfile, String packages, String version, String release, final String[] ignoreJDKClasses, boolean ignoreAllJdkClasses) {
         this.prj = prj;
         this.classes = classes;
         this.sigfile = sigfile;
         this.packages = packages;
         this.version = version;
         this.release = release;
-        this.ignoreJDKClasses = ignoreJDKClasses;
+        this.ignoreJDKClasses = Arrays.copyOf(ignoreJDKClasses, ignoreJDKClasses.length);
+        this.ignoreAllJdkClasses = ignoreAllJdkClasses;
     }
 
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -170,6 +180,11 @@ public final class SigtestGenerate extends AbstractMojo {
             
             @Override
             protected boolean isJDKExcludeEnabled() {
+                return ignoreAllJdkClasses;
+            }
+
+            @Override
+            protected String[] getIgnoreJDKClassEntries() {
                 return ignoreJDKClasses;
             }
         };

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestHandler.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestHandler.java
@@ -96,6 +96,13 @@ abstract class SigtestHandler {
             arg.add("-ApiVersion");
             arg.add(getVersion());
         }
+        final String[] ignoreJdkClassEntries = getIgnoreJDKClassEntries();
+        if (ignoreJdkClassEntries != null) {
+            for (String ignore : ignoreJdkClassEntries) {
+                arg.add("-IgnoreJDKClass");
+                arg.add(ignore);
+            }
+        }
         if (isJDKExcludeEnabled()) {
             arg.add("-IgnoreJDKClasses");
         }
@@ -263,6 +270,7 @@ abstract class SigtestHandler {
     protected abstract String getMail();
     protected abstract Boolean isFailOnError();
     protected abstract boolean isJDKExcludeEnabled();
+    protected abstract String[] getIgnoreJDKClassEntries();
     protected abstract void logInfo(String message);
     protected abstract void logError(String message);
 }


### PR DESCRIPTION
…Without an argument, this will act as -IgnoreJDKClasses.

One breaking change is renaming of the parameters in the maven plugins. However, this is likely not a big issue.

resolves #154 