### PR TITLE
[35] Allow newer JVM's to be used with the Release argument

### DIFF
--- a/.github/workflows/sigtest-ci.yml
+++ b/.github/workflows/sigtest-ci.yml
@@ -1,0 +1,52 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+
+name: Build and Test TCK sigtest Tooling
+
+on:
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - '.github/workflows/sigtest-ci.yml'
+      - 'tools/sigtest/**'
+  push:
+    branches:
+      - '**'
+    paths:
+      - '.github/workflows/sigtest-ci.yml'
+      - 'tools/sigtest/**'
+
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  build-sigtest-tools:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['17', '21', '23']
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: sigtest-jdk-${{ matrix.java }}
+        run:  |
+          cd tools/sigtest
+          mvn clean install -U -B -fae
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-reports-jdk-${{ matrix.java }}
+          path: '**/surefire-reports/'

--- a/tools/sigtest/pom.xml
+++ b/tools/sigtest/pom.xml
@@ -247,6 +247,17 @@
             </testResource>
         </testResources>
     </build>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.11.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -298,16 +309,19 @@
                 </exclusion>
             </exclusions>
         </dependency>
-	<dependency>
-	    <groupId>org.junit.jupiter</groupId>
-	    <artifactId>junit-jupiter-engine</artifactId>
-	    <version>5.10.2</version>
-	    <scope>test</scope>
+         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/classpath/Release.java
+++ b/tools/sigtest/src/main/java/com/sun/tdk/signaturetest/classpath/Release.java
@@ -40,9 +40,6 @@ public final class Release {
      * @return found version or null
      */
     public static Release find(int version) {
-        if (version > 21) {
-            return null;
-        }
         char ch = (char) (version < 10 ? '0' + version : 'A' + (version - 10));
         return RELEASES.get(ch);
     }


### PR DESCRIPTION
resolves #35 

This also adds some CI and refactored the `ReleaseTest` to be more dynamic.