### PR TITLE
generate goal (org.netbeans.apitest.SigtestGenerate) should have a way to specify other generate options like exclude specified subpackages in sigtest-maven-plugin

### DIFF
--- a/tools/sigtest/src/main/java/org/netbeans/apitest/Sigtest.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/Sigtest.java
@@ -42,6 +42,7 @@ public final class Sigtest extends Task {
     Path classpath;
     String version;
     String packages;
+    String excludes;
     ActionType action;
     Boolean failOnError;
     File report;
@@ -54,6 +55,10 @@ public final class Sigtest extends Task {
 
     public void setPackages(String s) {
         packages = s;
+    }
+
+    public void setExcludes(String s) {
+        excludes = s;
     }
 
     public void setAction(ActionType s) {
@@ -118,6 +123,11 @@ public final class Sigtest extends Task {
             @Override
             protected String getPackages() {
                 return packages;
+            }
+
+            @Override
+            protected String getExcludes() {
+                return excludes;
             }
 
             @Override

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCheck.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCheck.java
@@ -95,6 +95,8 @@ public final class SigtestCheck extends AbstractMojo {
     private String action;
     @Parameter(defaultValue = "")
     private String packages;
+    @Parameter(defaultValue = "")
+    private String excludes;
     @Parameter(defaultValue = "${project.build.directory}/surefire-reports/sigtest/TEST-${project.build.finalName}.xml")
     private File report;
     @Parameter(defaultValue = "true", property = "sigtest.fail")
@@ -108,16 +110,21 @@ public final class SigtestCheck extends AbstractMojo {
     }
 
     SigtestCheck(MavenProject prj, File classes, File sigfile, String action, String packages, File report, boolean failOnError, final String[] ignoreJDKClasses, boolean ignoreAllJDKClasses) {
-        this.prj = prj;
-        this.classes = classes;
-        this.sigfile = sigfile;
-        this.action = action;
-        this.packages = packages;
-        this.report = report;
-        this.failOnError = failOnError;
-        this.ignoreJDKClasses = Arrays.copyOf(ignoreJDKClasses, ignoreJDKClasses.length);
-        this.ignoreAllJDKClasses = ignoreAllJDKClasses;
+        this(prj, classes, sigfile, action, packages, report, failOnError, ignoreJDKClasses, ignoreAllJDKClasses, "");
     }
+
+    SigtestCheck(MavenProject prj, File classes, File sigfile, String action, String packages, File report, boolean failOnError, final String[] ignoreJDKClasses, boolean ignoreAllJDKClasses, final String excludes) {
+            this.prj = prj;
+            this.classes = classes;
+            this.sigfile = sigfile;
+            this.action = action;
+            this.packages = packages;
+            this.report = report;
+            this.failOnError = failOnError;
+            this.ignoreJDKClasses = Arrays.copyOf(ignoreJDKClasses, ignoreJDKClasses.length);
+            this.ignoreAllJDKClasses = ignoreAllJDKClasses;
+            this.excludes = excludes;
+        }
 
 
 
@@ -141,6 +148,11 @@ public final class SigtestCheck extends AbstractMojo {
             @Override
             protected String getPackages() {
                 return packages;
+            }
+
+            @Override
+            protected String getExcludes() {
+                return excludes;
             }
 
             @Override

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCompare.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestCompare.java
@@ -63,6 +63,8 @@ public final class SigtestCompare extends AbstractMojo {
     private File sigfile;
     @Parameter(defaultValue = "")
     private String packages;
+    @Parameter(defaultValue = "")
+    String excludes;
 
     @Parameter(property = "maven.compiler.release")
     private String release;
@@ -99,7 +101,7 @@ public final class SigtestCompare extends AbstractMojo {
             throw new MojoExecutionException("Cannot resolve " + artifact, ex);
         }
 
-        SigtestGenerate generate = new SigtestGenerate(prj, artifact.getFile(), sigfile, packages, releaseVersion, release, ignoreJDKClasses, ignoreAllJDKClasses);
+        SigtestGenerate generate = new SigtestGenerate(prj, artifact.getFile(), sigfile, packages, releaseVersion, release, ignoreJDKClasses, ignoreAllJDKClasses, excludes);
         generate.execute();
 
         SigtestCheck check = new SigtestCheck(prj, classes, sigfile, action, packages, report, failOnError, ignoreJDKClasses, ignoreAllJDKClasses);

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestGenerate.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestGenerate.java
@@ -55,6 +55,7 @@ import org.apache.maven.project.MavenProjectHelper;
   &lt;configuration&gt;
     &lt;release&gt;8&lt;/release&gt; &lt;!-- specify version of JDK API to use 6,7,8,...15 --&gt;
     &lt;packages&gt;org.yourcompany.app.api,org.yourcompany.help.api&lt;/packages&gt;
+    &lt;excludes&gt;org.yourcompany.app.api.internalonly,org.yourcompany.help.api.ignorethispackagealso&lt;/packages&gt;
   &lt;/configuration&gt;
 &lt;/plugin&gt;
  * </pre>
@@ -78,6 +79,8 @@ public final class SigtestGenerate extends AbstractMojo {
     private File sigfile;
     @Parameter(defaultValue = "")
     private String packages;
+    @Parameter(defaultValue = "")
+    String excludes;
     @Parameter(property = "maven.compiler.release")
     private String release;
     /**
@@ -101,14 +104,19 @@ public final class SigtestGenerate extends AbstractMojo {
     }
 
     SigtestGenerate(MavenProject prj, File classes, File sigfile, String packages, String version, String release, final String[] ignoreJDKClasses, boolean ignoreAllJdkClasses) {
+        this(prj, classes, sigfile, packages, version, release, ignoreJDKClasses, ignoreAllJdkClasses,"");
+    }
+
+    public SigtestGenerate(MavenProject prj, File file, File sigfile, String packages, String releaseVersion, String release, String[] ignoreJDKClasses, boolean ignoreAllJDKClasses, String excludes) {
         this.prj = prj;
         this.classes = classes;
         this.sigfile = sigfile;
         this.packages = packages;
-        this.version = version;
+        this.version = releaseVersion;
         this.release = release;
         this.ignoreJDKClasses = Arrays.copyOf(ignoreJDKClasses, ignoreJDKClasses.length);
         this.ignoreAllJdkClasses = ignoreAllJdkClasses;
+        this.excludes = excludes;
     }
 
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -127,6 +135,9 @@ public final class SigtestGenerate extends AbstractMojo {
             protected String getPackages() {
                 return packages;
             }
+
+            @Override
+            protected String getExcludes() { return excludes; }
 
             @Override
             protected File getFileName() {

--- a/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestHandler.java
+++ b/tools/sigtest/src/main/java/org/netbeans/apitest/SigtestHandler.java
@@ -126,6 +126,17 @@ abstract class SigtestHandler {
             arg.add(prefix.trim());
             arg.add(p);
         }
+        // Add each specified excludes package name to "-Exclude $PACKAGENAME
+        if (getExcludes() != null ) {
+            StringTokenizer excludesTokenizer = new StringTokenizer(getExcludes(), ",:;");
+            while (excludesTokenizer.hasMoreTokens()) {
+                String p = excludesTokenizer.nextToken().trim();
+                String prefix = "-Exclude "; // NOI18N
+                arg.add(prefix.trim());
+                arg.add(p);
+            }
+        }
+
         if (getClasspath() != null) {
             StringBuffer sb = new StringBuffer();
             String pref = "";
@@ -262,6 +273,7 @@ abstract class SigtestHandler {
 
     protected abstract Integer getRelease();
     protected abstract String getPackages();
+    protected abstract String getExcludes();
     protected abstract File getFileName();
     protected abstract String getAction();
     protected abstract String getVersion();


### PR DESCRIPTION
For addressing https://github.com/eclipse-ee4j/jakartaee-tck-tools/issues/158

Example usage:

```
        <profile>
            <id>jakarta.cdi</id>
            <!--
            includes jakarta.decorator and jakarta.enterprise but exclude jakarta.enterprise.concurrent
            -->
            <build>
                <plugins>
                    <plugin>
                        <groupId>jakarta.tck</groupId>
                        <artifactId>sigtest-maven-plugin</artifactId>
                        <version>${version.sigtest-maven-plugin}</version>

                        <configuration>
                            <sigfile>jakarta.cdi.sig</sigfile>
                            <release>17</release>
                            <excludes>jakarta.enterprise.concurrent</excludes>
                            <packages>jakarta.enterprise.**, jakarta.decorator.**</packages>
                        </configuration>
                        <executions>
                            <execution>
                                <goals>
                                    <goal>generate</goal>
                                </goals>
                            </execution>
                        </executions>
                    </plugin>
                </plugins>
            </build>
        </profile>

```