### PR TITLE
Add properties required for the signature tests. These properties can…

### DIFF
--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
@@ -100,6 +100,12 @@ public class TsTestPropsBuilder {
             "whitebox-xa-param",
             "work.dir",
             "ws_wait",
+            // Signature test properties
+            "bin.dir",
+            "javaee.level",
+            "current.keywords",
+            "optional.tech.packages.to.ignore",
+            "jimage.dir",
     };
 
     /**


### PR DESCRIPTION
… be set in a jte file.

Opening this as a draft for now, but we likely need these or we need to rename the properties used in the signature tests for the Jakarta EE platform TCK.