### PR TITLE
Remove the unused signature test properties.

### DIFF
--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
@@ -103,7 +103,6 @@ public class TsTestPropsBuilder {
             // Signature test properties
             "bin.dir",
             "javaee.level",
-            "current.keywords",
             "optional.tech.packages.to.ignore",
             "jimage.dir",
     };


### PR DESCRIPTION
This property is only used in the `com.sun.ts.tests.signaturetest.SigTestData.getCurrentKeywords()`. However, that method is never used.