### PR TITLE
Support Two-Line AppClient Test Status

### DIFF
--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientMethodExecutor.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientMethodExecutor.java
@@ -147,9 +147,6 @@ public class AppClientMethodExecutor implements ContainerMethodExecutor {
                 if (!remnant.isEmpty()) {
                     description = line;
                     status = MainStatus.parseStatus(line);
-                    if (status == null) {
-                        status = MainStatus.FAILED;
-                    }
                     // Format of line is STATUS:StatusText.Reason
                     // see com.sun.javatest.Status#exit()
                     int reasonStart = line.indexOf('.');
@@ -161,6 +158,11 @@ public class AppClientMethodExecutor implements ContainerMethodExecutor {
                     expectReason = true;
                 }
             }
+        }
+
+        // Fail if no valid status ever found
+        if (status == null) {
+            status = MainStatus.FAILED;
         }
 
         if (!sawStatus) {


### PR DESCRIPTION
In testing with Open Liberty, app client tests were returning status like the following:

[err] STATUS:
[err] Passed.

Because it is split between two lines, the status parsing logic was not able to determine what the result was. I've added a case that will handle this scenario while maintaining support for the original case.