### PR TITLE
Add Option to Isolate AppClient EAR Installs

### DIFF
--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
@@ -82,6 +82,12 @@ public class AppClientProtocolConfiguration implements ProtocolConfiguration, Pr
     private String clientEarDir = "target/appclient";
 
     /**
+     * Flag to ensure that only one Application Client EAR test artifact is extracted at a time.
+     * Default value is false.
+     */
+    private boolean isolateClientEars = false;
+
+    /**
      * Maximum time in milliseconds to wait for the Application Client process to complete.
      * Default value is 60000ms (1 minute).
      */
@@ -303,6 +309,20 @@ public class AppClientProtocolConfiguration implements ProtocolConfiguration, Pr
      */
     public void setUnpackClientEar(boolean unpackClientEar) {
         this.unpackClientEar = unpackClientEar;
+        this.anySetter = true;
+    }
+
+    public boolean isIsolateClientEars() {
+        return isolateClientEars;
+    }
+
+    /**
+     * Set to true to clear the clientEarDir before extracting a new appclient ear test artifact. The default is false.
+     * This is useful if the vendor appclient loads all of the ears in clientEarDir by default.
+     * @param isolateClientEars
+     */
+    public void setIsolateClientEars(boolean isolateClientEars) {
+        this.isolateClientEars = isolateClientEars;
         this.anySetter = true;
     }
 


### PR DESCRIPTION
Some vendors, like Open Liberty, will try to load all of the ears that have been deployed to the app client over the course of a test run by default. This added option updates the deployment code so that only one ear will be deployed to the app client at a time.