### PR TITLE
[Issue_183] Do not use application.xml as the source of a deploymentName

### DIFF
--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientCmd.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientCmd.java
@@ -41,8 +41,9 @@ public class AppClientCmd {
      * @param vehicleArchiveName - the name of the vehicle archive to pass to the app client
      * @param clientAppArchive - the appclient archive
      * @param clientStubJar - optional client stub jar, may be null
+     * @param clientEarName - the name of ear deployment
      */
-    record AppClientInfo(String deploymentName, String vehicleArchiveName, String clientAppArchive, String clientStubJar) {}
+    record AppClientInfo(String deploymentName, String vehicleArchiveName, String clientAppArchive, String clientStubJar, String clientEarName) {}
 
     private static final Logger LOGGER = Logger.getLogger(AppClientCmd.class.getName());
 
@@ -169,6 +170,10 @@ public class AppClientCmd {
             }
             if(arg.contains("${clientStubJar}")) {
                 arg = arg.replaceAll("\\$\\{clientStubJar}", appClientInfo.clientStubJar);
+                cmdLine[n] = arg;
+            }
+            if(arg.contains("${clientEarName}")) {
+                arg = arg.replaceAll("\\$\\{clientEarName}", appClientInfo.clientEarName);
                 cmdLine[n] = arg;
             }
         }

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientDeploymentPackager.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientDeploymentPackager.java
@@ -75,7 +75,7 @@ public class AppClientDeploymentPackager implements DeploymentPackager {
         log.info("Generating deployment for: " + deploymentName);
 
         // clientEarName will be the EAR name for EAR deployments
-        String clientEarName = testDeployment.getDeploymentName().endsWith(".ear") ? testDeployment.getDeploymentName() : testDeployment.getDeploymentName() + ".ear";
+        String clientEarName = deploymentName.endsWith(".ear") ? deploymentName : deploymentName + ".ear";
         log.info("clientEarName: " + clientEarName);
 
         Collection<Archive<?>> auxiliaryArchives = testDeployment.getAuxiliaryArchives();

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientDeploymentPackager.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientDeploymentPackager.java
@@ -66,11 +66,10 @@ public class AppClientDeploymentPackager implements DeploymentPackager {
     public Archive<?> generateDeployment(TestDeployment testDeployment, Collection<ProtocolArchiveProcessor> processors) {
         Archive<?> archive = testDeployment.getApplicationArchive();
         String deploymentName = testDeployment.getDeploymentName();
-        String xmlDeploymentName = deploymentName;
         String archiveName = archive.getName();
-        if(!archiveName.equals(xmlDeploymentName)) {
+        if(!archiveName.equals(deploymentName)) {
             // The archive name does not match the @Deployment(name), so use the archive name as that is what a server will use
-            xmlDeploymentName = archiveName.substring(0, archiveName.length()-4);
+            deploymentName = archiveName.substring(0, archiveName.length()-4);
         }
         log.info("Generating deployment for: " + deploymentName);
 
@@ -97,9 +96,6 @@ public class AppClientDeploymentPackager implements DeploymentPackager {
                         } else {
                             log.info("Using EAR application/library-directory: "+earLibDir);
                         }
-                    } else if(line.contains("<application-name>")) {
-                        xmlDeploymentName = line.substring(line.indexOf("<app") + 18, line.indexOf("</"));
-                        log.info("Using EAR application/application-name: " + xmlDeploymentName);
                     }
                 }
             } catch (IOException e) {
@@ -126,7 +122,7 @@ public class AppClientDeploymentPackager implements DeploymentPackager {
 
         AppClientProtocolConfiguration config = (AppClientProtocolConfiguration) testDeployment.getProtocolConfiguration();
         config.setEarLibDir(earLibDir);
-        config.setDeploymentName(xmlDeploymentName);
+        config.setDeploymentName(deploymentName);
         String mainClass = determineAppMainJar(ear, config);
         log.info("mainClass: " + mainClass);
         /*

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientDeploymentPackager.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientDeploymentPackager.java
@@ -74,11 +74,8 @@ public class AppClientDeploymentPackager implements DeploymentPackager {
         }
         log.info("Generating deployment for: " + deploymentName);
 
-        String clientEarName = testDeployment.getDeploymentName();
-        // The archive name does not match the @Deployment(name), so use the archive name as that is what a server will use
-        if(!archiveName.equals(clientEarName)) {
-            clientEarName = archiveName.substring(0, archiveName.length()-4);
-        }
+        // clientEarName will be the EAR name for EAR deployments
+        String clientEarName = testDeployment.getDeploymentName().endsWith(".ear") ? testDeployment.getDeploymentName() : testDeployment.getDeploymentName() + ".ear";
         log.info("clientEarName: " + clientEarName);
 
         Collection<Archive<?>> auxiliaryArchives = testDeployment.getAuxiliaryArchives();

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientDeploymentPackager.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientDeploymentPackager.java
@@ -66,12 +66,20 @@ public class AppClientDeploymentPackager implements DeploymentPackager {
     public Archive<?> generateDeployment(TestDeployment testDeployment, Collection<ProtocolArchiveProcessor> processors) {
         Archive<?> archive = testDeployment.getApplicationArchive();
         String deploymentName = testDeployment.getDeploymentName();
+        String xmlDeploymentName = deploymentName;
         String archiveName = archive.getName();
-        if(!archiveName.equals(deploymentName)) {
+        if(!archiveName.equals(xmlDeploymentName)) {
             // The archive name does not match the @Deployment(name), so use the archive name as that is what a server will use
-            deploymentName = archiveName.substring(0, archiveName.length()-4);
+            xmlDeploymentName = archiveName.substring(0, archiveName.length()-4);
         }
         log.info("Generating deployment for: " + deploymentName);
+
+        String clientEarName = testDeployment.getDeploymentName();
+        // The archive name does not match the @Deployment(name), so use the archive name as that is what a server will use
+        if(!archiveName.equals(clientEarName)) {
+            clientEarName = archiveName.substring(0, archiveName.length()-4);
+        }
+        log.info("clientEarName: " + clientEarName);
 
         Collection<Archive<?>> auxiliaryArchives = testDeployment.getAuxiliaryArchives();
         EnterpriseArchive ear = (EnterpriseArchive) archive;
@@ -96,6 +104,9 @@ public class AppClientDeploymentPackager implements DeploymentPackager {
                         } else {
                             log.info("Using EAR application/library-directory: "+earLibDir);
                         }
+                    } else if(line.contains("<application-name>")) {
+                        xmlDeploymentName = line.substring(line.indexOf("<app") + 18, line.indexOf("</"));
+                        log.info("Using EAR application/application-name: " + xmlDeploymentName);
                     }
                 }
             } catch (IOException e) {
@@ -122,7 +133,8 @@ public class AppClientDeploymentPackager implements DeploymentPackager {
 
         AppClientProtocolConfiguration config = (AppClientProtocolConfiguration) testDeployment.getProtocolConfiguration();
         config.setEarLibDir(earLibDir);
-        config.setDeploymentName(deploymentName);
+        config.setDeploymentName(xmlDeploymentName);
+        config.setClientEarName(clientEarName);
         String mainClass = determineAppMainJar(ear, config);
         log.info("mainClass: " + mainClass);
         /*

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientMethodExecutor.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientMethodExecutor.java
@@ -94,6 +94,7 @@ public class AppClientMethodExecutor implements ContainerMethodExecutor {
                 String appArchiveName = appClientArchiveName.name();
                 String vehicleArchiveName = determineVehicleArchiveName(testVehicle);
                 String deploymentName = config.getDeploymentName();
+                String clientEarName = config.getClientEarName();
 
                 String appArchiveStubJarName = null;
                 if(config.needsStubs() && deploymentMonitor.needsStubs()) {
@@ -104,7 +105,7 @@ public class AppClientMethodExecutor implements ContainerMethodExecutor {
                 }
 
                 String[] additionalAgrs = TsTestPropsBuilder.runArgs(config, deployment, testMethodExecutor);
-                AppClientCmd.AppClientInfo appClientInfo = new AppClientCmd.AppClientInfo(deploymentName, vehicleArchiveName, appArchiveName, appArchiveStubJarName);
+                AppClientCmd.AppClientInfo appClientInfo = new AppClientCmd.AppClientInfo(deploymentName, vehicleArchiveName, appArchiveName, appArchiveStubJarName, clientEarName);
                 appClient.run(appClientInfo, additionalAgrs);
             } catch (Exception ex) {
                 result = TestResult.failed(ex);

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
@@ -134,7 +134,7 @@ public class AppClientProtocolConfiguration implements ProtocolConfiguration, Pr
     private String deploymentName;
 
     /**
-     * The name of the EAR archive.
+     * The name of the EAR (e.g. exampleDeploymentName.ear).
      */
     private String clientEarName;
     /**

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
@@ -134,7 +134,7 @@ public class AppClientProtocolConfiguration implements ProtocolConfiguration, Pr
     private String deploymentName;
 
     /**
-     * The name of the EAR (e.g. exampleDeploymentName.ear).
+     * The base name of the EAR including the .ear extension (e.g. exampleDeploymentName.ear).
      */
     private String clientEarName;
     /**

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
@@ -132,6 +132,11 @@ public class AppClientProtocolConfiguration implements ProtocolConfiguration, Pr
      * The name of the ear deployment from the ear archive name, or the application.xml/application-name
      */
     private String deploymentName;
+
+    /**
+     * The name of the EAR archive.
+     */
+    private String clientEarName;
     /**
      * The name of the jar in the application client ear as determined by the jar with the Main-Class element.
      */
@@ -357,6 +362,14 @@ public class AppClientProtocolConfiguration implements ProtocolConfiguration, Pr
      */
     public void setDeploymentName(String deploymentName) {
         this.deploymentName = deploymentName;
+    }
+
+    public void setClientEarName(String clientEarName) {
+        this.clientEarName = clientEarName;
+    }
+
+    public String getClientEarName() {
+        return clientEarName;
     }
 
     public AppClientArchiveName getAppClientArchiveName() {

--- a/arquillian/appclient/src/test/java/test/org/jboss/arquillian/protocol/AppClientConfigTest.java
+++ b/arquillian/appclient/src/test/java/test/org/jboss/arquillian/protocol/AppClientConfigTest.java
@@ -144,6 +144,8 @@ public class AppClientConfigTest {
             found &= clientEarLibClasspath.contains(path);
         }
         Assertions.assertTrue(found, "Classpath should contain all expected paths");
+        Assertions.assertTrue(config.getClientEarName().equals(ear.getName()), "config.getClientEarName() (" + config.getClientEarName() +
+                ") is expected to be the same as ear.getName() (" + ear.getName() + ")");
     }
 
     @Test


### PR DESCRIPTION
Resolves #183

This also related to EE 11 TCK challenge https://github.com/jakartaee/platform-tck/issues/2670